### PR TITLE
Update Taxonomy -> 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ The version number is in the form of 3 digits 'A.B.C':
 ## Current Version
 
 [Sigma 1.0.1](Sigma_1_0_1.md)  
-[Taxonomy 1.0.0](Taxonomy_1_0_0.md)  
+[Taxonomy 1.1.0](Taxonomy_1_1_0.md)  
 [Tags 1.0.0](Tags_1_0_0.md)
 
 ## Work in Progress
 
-This section lists upcoming developments and changes to the standard. 
+This section lists upcoming developments and changes to the standard.
 
 [Sigma 2.0.0](wip/Sigma_2_0_0.md)  
 [Sigma Correlations](wip/Sigma_Correlations.md)

--- a/Sigma_1_0_1.md
+++ b/Sigma_1_0_1.md
@@ -54,7 +54,7 @@
 
 To keep the file names interoperable use the following:
 
-- Length between 10 and 70 characters 
+- Length between 10 and 70 characters
 - Lowercase
 - No special characters only letters (a-z) and digits (0-9)
 - Use `_` instead of a space
@@ -298,7 +298,6 @@ Declares the status of the rule:
 - deprecated: the rule is replace or cover by another one. The link is made by the `related` field.
 - unsupported: the rule can not be use in its current state (special correlation log, home-made fields)
 
-
 ### Description (optional)
 
 **Attribute:** description
@@ -339,7 +338,7 @@ The "category" value is used to select all log files written by a certain group 
 
 The "product" value is used to select all log outputs of a certain product, e.g. all Windows Eventlog types including "Security", "System", "Application" and the new log types like "AppLocker" and "Windows Defender".
 
-Use the "service" value to select only a subset of a product's logs, like the "sshd" on Linux or the "Security" Eventlog on Windows systems. 
+Use the "service" value to select only a subset of a product's logs, like the "sshd" on Linux or the "Security" Eventlog on Windows systems.
 
 The "definition" can be used to describe the log source, including some information on the log verbosity level or configurations that have to be applied. It is not automatically evaluated by the converters but gives useful information to readers on how to configure the source to provide the necessary events used in the detection.
 
@@ -376,7 +375,7 @@ A definition that can consist of two different data structures - lists and maps.
 Wildcards are used when part of the text is random.  
 You can use :
 
-* `?` to replace a single mandatory character 
+* `?` to replace a single mandatory character
 * `*` to replace an unbounded length wildcard
 
 example  :
@@ -447,7 +446,7 @@ detection:
 condition: selection
 ```
 
-Matches on Eventlog 'Security' **and** Event ID 4679 **and** TicketOptions 0x40810000 **and** TicketEncryption 0x17 
+Matches on Eventlog 'Security' **and** Event ID 4679 **and** TicketOptions 0x40810000 **and** TicketEncryption 0x17
 
 ```yml
 detection:
@@ -477,6 +476,7 @@ fieldmappings:
 2. For new or rarely used fields, use them as they appear in the log source and strip all spaces. (That means: Only, if the field is not already mapped to another field name.) On Windows event log sources, use the field names of the details view as the general view might contain localized field names.
 
 Examples:
+
 * `New Value` -> `NewValue`
 * `SAM User Account` -> `SAMUserAccount`
 
@@ -485,10 +485,12 @@ Examples:
     2. In the `<EventData>` body of the event the field name is given by the `Name` attribute of the `Data` tag.
 
 Examples i:
+
 * `<Provider Name="Service Control Manager" Guid="[...]" EventSourceName="[...]" />` will be `Provider_Name`
 * ` <Execution ProcessID="788" ThreadID="792" />` will be `Execution_ProcessID`
 
 Examples ii:
+
 * `<Data Name="User">NT AUTHORITY\SYSTEM</Data>` will be `User`
 * `<Data Name="ServiceName">MpKsl4eaa0a76</Data>` will be `ServiceName`
 

--- a/Tags_1_0_0.md
+++ b/Tags_1_0_0.md
@@ -1,4 +1,4 @@
-# Tags <!-- omit in toc --> 
+# Tags <!-- omit in toc -->
 
 This page defines some standardized tags that can be used to categorize Sigma rules.
 
@@ -6,11 +6,13 @@ This page defines some standardized tags that can be used to categorize Sigma ru
 * Release date 2022/09/18
 
 History:
+
 * 2022/09/18 Tags V1.0.0
   * Initial formalisation from the sigma wiki
 * 2017 Sigma creation
 
 # Summary
+
 - [Summary](#summary)
 - [Namespaces](#namespaces)
   - [Namespace: attack](#namespace-attack)
@@ -31,6 +33,7 @@ History:
 * s*1234*: Refers to [software](https://attack.mitre.org/wiki/Software)
 
 Tactics:
+
 * initial_access: [Initial Access](https://attack.mitre.org/tactics/TA0001/)
 * execution: [Execution](https://attack.mitre.org/tactics/TA0002/)
 * persistence: [Persistence](https://attack.mitre.org/tactics/TA0003/)
@@ -55,5 +58,3 @@ Use the CVE tag from the [mitre](https://cve.mitre.org) in lower case. Example t
 ## Namespace: tlp
 
 All TLP levels defined by the [FIRST TLP-SIG](https://www.first.org/tlp/) in lower case. Example tag: `tlp.amber`.
-
-

--- a/Taxonomy_1_1_0.md
+++ b/Taxonomy_1_1_0.md
@@ -1,7 +1,7 @@
-# Sigma Taxonomy <!-- omit in toc --> 
+# Sigma Taxonomy <!-- omit in toc -->
 
-* Version 1.0.0
-* Release date 2022/09/18
+* Version 1.1.0
+* Release date 2022/09/19
 
 This page defines field names and log sources that should be used to ensure sharable rules.
 
@@ -68,7 +68,6 @@ For a better comprehension, they are organized by the name of the rules director
 | Linux   | product: linux<br>service: syslog              |
 | Linux   | product: linux<br>service: vsftpd              |
 
-
 ## Macos folder
 
 | Product | Logsource                                    | Event |
@@ -115,8 +114,8 @@ For a better comprehension, they are organized by the name of the rules director
 | windows | category: ps_classic_provider_start<br>product: windows           | EventID: 600<br>Channel: Windows PowerShell                                                                                                                                                                                |
 | windows | category: ps_classic_script<br>product: windows                   | EventID: 800<br>Channel: Windows PowerShell                                                                                                                                                                                |
 | windows | category: ps_classic_start<br>product: windows                    | EventID: 400<br>Channel: Windows PowerShell                                                                                                                                                                                |
-| windows | category: ps_module<br>product: windows                           | EventID: 4103<br>Channel: Microsoft-Windows-PowerShell/Operational                                                                                                                                                         |
-| windows | category: ps_script<br>product: windows                           | EventID: 4104<br>Channel: Microsoft-Windows-PowerShell/Operational                                                                                                                                                         |
+| windows | category: ps_module<br>product: windows                           | EventID: 4103<br>Channel:<br> - Microsoft-Windows-PowerShell/Operational<br> - PowerShellCore/Operational                                                                                                                                                         |
+| windows | category: ps_script<br>product: windows                           | EventID: 4104<br>Channel:<br> - Microsoft-Windows-PowerShell/Operational<br> - PowerShellCore/Operational                                                                                                                                                         |
 | windows | category: raw_access_thread<br>product: windows                   | EventID: 9<br>Channel: Microsoft-Windows-Sysmon/Operational                                                                                                                                                                |
 | windows | category: registry_add<br>product: windows                        | EventID: 12<br>Channel: Microsoft-Windows-Sysmon/Operational                                                                                                                                                               |
 | windows | category: registry_delete<br>product: windows                     | EventID: 12<br>Channel: Microsoft-Windows-Sysmon/Operational                                                                                                                                                               |
@@ -160,7 +159,7 @@ For a better comprehension, they are organized by the name of the rules director
 
 Process creation events can be defined with the generic log source category *process_creation*. The event scope can be further restricted with *product*. Example for a process creation event log source restricted to Windows:
 
-```
+```yml
 category: process_creation
 product: windows
 ```
@@ -196,7 +195,7 @@ The field names follow the field names used in [Sysmon](https://docs.microsoft.c
 ### Other Generic Rule Categories
 
 We align our field names to the field names that [Sysmon](https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon) uses.
-You can find all possible field values in the [Sysmon Community Guide](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/chapters/Sysmon.md) and on [UltimateWindowsSecurity.com](https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/default.aspx). 
+You can find all possible field values in the [Sysmon Community Guide](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/chapters/Sysmon.md) and on [UltimateWindowsSecurity.com](https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/default.aspx).
 
 ## Specific
 
@@ -219,7 +218,7 @@ You can find all possible field values in the [Sysmon Community Guide](https://g
   * `service: access`: Access logs
   * `service: error`: Error logs
 * `category: proxy`
-  * Field Name according to [W3C Extended Log File Format](https://www.w3.org/TR/WD-logfile.html). Additional W3 examples can be found from [Microsoft](https://docs.microsoft.com/en-us/windows/win32/http/w3c-logging). 
+  * Field Name according to [W3C Extended Log File Format](https://www.w3.org/TR/WD-logfile.html). Additional W3 examples can be found from [Microsoft](https://docs.microsoft.com/en-us/windows/win32/http/w3c-logging).
   * Field names:
     * c-uri: URL requested by client
     * c-uri-extension: Extension of the URL. Commonly is the requested extension of a file name

--- a/Taxonomy_1_1_0.md
+++ b/Taxonomy_1_1_0.md
@@ -1,7 +1,7 @@
 # Sigma Taxonomy <!-- omit in toc -->
 
 * Version 1.1.0
-* Release date 2022/09/19
+* Release date 2022/10/19
 
 This page defines field names and log sources that should be used to ensure sharable rules.
 


### PR DESCRIPTION
This PR covers the following:

- Update the Taxonomy to 1.1.0 with the addition of the `PowerShellCore/Operational` channel as described in [PR #3603](https://github.com/SigmaHQ/sigma/pull/3606)
- Removed/Added some spaces to conform with the MD format