### PR TITLE
refactor: moving tags up, level should be the last field !important

### DIFF
--- a/Sigma_1_0_1.md
+++ b/Sigma_1_0_1.md
@@ -110,6 +110,7 @@ status [optional]
 description [optional]
 author [optional]
 references [optional]
+tags [optional]
 logsource
    category [optional]
    product [optional]
@@ -126,7 +127,6 @@ detection
 fields [optional]
 falsepositives [optional]
 level [optional]
-tags [optional]
 ...
 [arbitrary custom fields]
 ```


### PR DESCRIPTION
Tags shouldn't be at the end of the rule, but right after references and before the log source definition. 
The last field in a rule is a special place, just like the first field. They are easier to spot. 
Most user's aren't interested in the tags, but the level of a rule has a special importance. It should always be the last field of a rule because it makes it easier to spot that field. 