### PR TITLE
Fixed missing link to rules for event_count

### DIFF
--- a/Sigma_meta_rules.md
+++ b/Sigma_meta_rules.md
@@ -264,6 +264,8 @@ title: Failed login
 id: 0e95725d-7320-415d-80f7-004da920fc12
 action: correlation
 type: value_count
+rules: 
+    - 5638f7c0-ac70-491d-8465-2a65075e0d86
 field: User
 group-by:
     - ComputerName


### PR DESCRIPTION
event_count hat no referenenced rules. With this the sigma meta rule would not work in the way described. 
Added the missing rule failed logon to fix the missing link.