### PR TITLE
Fixed link to meta rules md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The version number is in the form of 3 digits 'A.B.C':
 ## Current Version
 
 The Sigma rules format specifications is described in the file [Sigma_specification](Sigma_specification.md)  
-The Sigma Meta-rules format specifications is described in the file [Sigma_meta_rules](Sigma_meta_rules.md)  
+The Sigma Meta-rules format specifications is described in the file [Sigma_meta_rules](appendix_meta_rules.md)  
 
 There exists other files in the repository to describe the different modifiers, fields and tags to be used in Sigma rules:
 


### PR DESCRIPTION
The link in README.md to Sigma Meta Rules is broken. Changed from meta_rules.md to appendix_meta_rules.md