### PR TITLE
Fix invalid rules and examples in appendix_meta_rules.md

### DIFF
--- a/appendix_meta_rules.md
+++ b/appendix_meta_rules.md
@@ -346,7 +346,7 @@ Simple example : More than or equal 100 failed login attempts to a destination h
 title: Many failed logins
 id: 0e95725d-7320-415d-80f7-004da920fc11
 correlation:
-type: event_count
+  type: event_count
   rules:
       - 5638f7c0-ac70-491d-8465-2a65075e0d86
   group-by:

--- a/appendix_meta_rules.md
+++ b/appendix_meta_rules.md
@@ -676,4 +676,5 @@ detection:
         EventID:
           - 528
           - 4624
+    condition: selection
 ```


### PR DESCRIPTION
(Fix two typos) 
The example correlation had an invalid `detection` block.