### PR TITLE
Update V2.0.0 correlation section

### DIFF
--- a/appendix_meta_rules.md
+++ b/appendix_meta_rules.md
@@ -103,49 +103,6 @@ Example: A valid GPO script that triggers multiple Sigma rules.
 # Correlation rules
 
 The rules in a multi-document YAML that build a correlation rule are not producing individual, independent queries. They are used as a tool to define more complex constructs out of basic Sigma detections. Therefore only the outermost correlation rule may define meta information such as status, level, date or anything else.
-<!--  Discution from the former PR
-secDre4mer Nov 27, 2023
-Should be "generate".
-Also: This implies that with this change, no current rules will generate queries (since they don't have that field).
-
-phantinuss Nov 27, 2023 •
-Nah you are right. It's affecting all existing rules.
-But +1 on the rename
-
-secDre4mer Nov 27, 2023
-
-About rename: I find it a bit counter-intuitive that this field is called "generate". From a technical perspective it's correct (no queries are generated), but from a high-level user perspective, I don't know what's generated. That it defaults to true (according to documentation below) is also strange / unexpected.
-Maybe we could invert it and call it silent instead? That would have the "expected" behaviour of defaulting to a zero value (that is, false) and it clarifies what this does (if it's set, the rule is silent and does not produce matches).
-
- Neo23x0 Dec 14, 2023
-
-The default behaviour should be that the single rules in a correlation rule are silent.
-
-Examples:
-
-    The multiple failed logon followed by a successful logon example. You wouldn't want to trigger a rule and see a match for every failed logon.
-    A rule that detects recon activity. You wouldn't want to see matches for every "net" command execution or every "ping".
-
-So, the default behaviour of the field "silent", if we call it that way, should be "true" and the user can set it to "false" if he wants the single rules in the correlation to show up.
-
-I wouldn't overcomplicate it with lists of selections.
-But this opinion isn't by far as strong as the one I have on the default behaviour.
-We can allow the user to provide a list of rule name that he wants to see matches for. (a list that disables the "silent" for 1-n of the sub rules)
-
-phantinuss Dec 14, 2023 •
-
-The issue that @secDre4mer raised was that how does that affect existing rules.
-
-My proposal is to define it like this:
-
-    We can switch back to silent is false by default (implicitly). And silent is true if you set it to true explicitly or if there is no level defined in a rule, which is the case for all "in-file/multi-document" correlation rules that are only used as aggregates.
-
- phantinuss Dec 14, 2023
-
-Another idea how we could specify it:
-If a rule has no level set, the default level is "informational". That also should work and we have no need to define either "generate" or "silent" at all.
-
--->
 
 ## File Structure
 ### YAML File

--- a/appendix_meta_rules.md
+++ b/appendix_meta_rules.md
@@ -18,16 +18,15 @@ The following document defines the standardized correlation that can be used in 
     - [Syntax](#syntax)
   - [Components](#components)
     - [Title](#title)
-    - [Rule Identification](#rule-identification)
+    - [Rule Identification  (optional)](#rule-identification--optional)
     - [Related rules](#related-rules)
     - [Correlation type](#correlation-type)
     - [Grouping](#grouping)
     - [Values Field Name selection](#values-field-name-selection)
     - [Time Selection](#time-selection)
     - [Condition Selection](#condition-selection)
-    - [Level](#level)
-    - [Aliases](#aliases)
-    - [Generate](#generate)
+    - [Level  (optional)](#level--optional)
+    - [Aliases  (optional)](#aliases--optional)
   - [Metric Conditions](#metric-conditions)
   - [Event Count (event\_count)](#event-count-event_count)
   - [Value Count (value\_count)](#value-count-value_count)
@@ -136,7 +135,7 @@ Like sigma rules , correlation rules have a title and a unique id to identify th
 A brief title for the rule that should contain what the rule is supposed to detect (max. 256 characters)
 <!-- shouldn't it be mandatory ?-->
 
-### Rule Identification
+### Rule Identification  (optional)
 
 **Attribute:** id
 
@@ -255,34 +254,19 @@ condition
     gte: 100
 ```
 
-### Level
+### Level  (optional)
 
 **Attribute:**  level
 
 defines a severity level adjustment if the correlation matches.
 This allows to give single event hits a low or informational severity and increasing this to higher levels in case of correlating appearances of events.
 
-### Aliases
+### Aliases  (optional)
 
 **Attribute:** aliases
 
 defines field name aliases that are applied to correlated Sigma rules.
 The defined aliases can then be defined in `group-by` and allows aggregation across different fields in different event types.
-
-### Generate
-
-**Attribute:** generate
-<!-- TODO: Discuss: I think we agreed on switching the default behaviour back to 'true' -->
-Usually if a Sigma rule is referenced by a correlation rule the query for the rule itself is not generated anymore.
-This attribute overrides the behavior.
-The idea is that two rules are created:
-
-* one for the singular event with informational severity.
-* the correlation rule that takes appearance of multiple events into account with a higher severity.
-
-***************************************************
-****************** NEED AN EXAMPLE ****************
-***************************************************
 
 ## Metric Conditions
 

--- a/appendix_meta_rules.md
+++ b/appendix_meta_rules.md
@@ -27,7 +27,6 @@ The following document defines the standardized correlation that can be used in 
     - [Condition Selection](#condition-selection)
     - [Level  (optional)](#level--optional)
     - [Aliases  (optional)](#aliases--optional)
-  - [Metric Conditions](#metric-conditions)
   - [Event Count (event\_count)](#event-count-event_count)
   - [Value Count (value\_count)](#value-count-value_count)
   - [Temporal Proximity (temporal)](#temporal-proximity-temporal)
@@ -238,9 +237,21 @@ It is a map of exactly one condition criterion:
 
 Example:
 ```yaml
-condition
+condition:
     gte: 100
 ```
+
+To select a range , you can use the map AND
+
+Example "101 to 200":
+```yaml
+condition:
+    gt: 100
+    lte: 200
+```
+
+If you need more complex constructs, you can always chain correlation rules together.  
+See the examples at the far bottom, for more details.
 
 ### Level  (optional)
 
@@ -255,20 +266,6 @@ This allows to give single event hits a low or informational severity and increa
 
 defines field name aliases that are applied to correlated Sigma rules.
 The defined aliases can then be defined in `group-by` and allows aggregation across different fields in different event types.
-
-## Metric Conditions
-
-The field condition defines the condition that must evaluate to true to generate a match.
-It operates on the count resulting from an event_count or value_count correlation.
-It is a map of exactly one condition criterion:
-
-* `gt`: The count must be greater than the given value
-* `gte`: The count must be greater than or equal the given value
-* `lt`: The count must be lesser than the given value
-* `lte`: The count must be lesser than or equal the given value
-* `range`: The count must be in the given range specified as value in the format `min..max`. The range includes the min and max values.
-
-If you need more complex constructs, you can always chain correlation rules together. See the examples at the far bottom, for more details.
 
 ## Event Count (event_count)
 

--- a/appendix_meta_rules.md
+++ b/appendix_meta_rules.md
@@ -102,8 +102,7 @@ Example: A valid GPO script that triggers multiple Sigma rules.
 
 # Correlation rules
 
-All rules in a file, basic event rules as well as correlations, might contain an additional attribute called "generate".
-If it is set to true, the rule will generate a query, even if it is referred to by other correlations. Otherwise by default no "standalone" query would be generated for this rule.
+The rules in a multi-document YAML that build a correlation rule are not producing individual, independent queries. They are used as a tool to define more complex constructs out of basic Sigma detections. Therefore only the outermost correlation rule may define meta information such as status, level, date or anything else.
 <!--  Discution from the former PR
 secDre4mer Nov 27, 2023
 Should be "generate".

--- a/appendix_meta_rules.md
+++ b/appendix_meta_rules.md
@@ -396,7 +396,6 @@ correlation:
 
 All events defined by the rules referred by the rule field must occur in the time frame defined by timespan.
 The values of fields defined in group-by must all have the same value (e.g. the same host or user).
-If the bool value `ordered` is set to true, the events should occur in the given order.
 
 The time frame should not be restricted to boundaries if this is not required by the given backend.
 
@@ -413,7 +412,6 @@ type: temporal
       - ComputerName
       - User
   timespan: 5m
-  ordered: false
 ```
 
 ## Ordered Temporal Proximity (temporal_ordered)
@@ -425,14 +423,13 @@ Example: many failed logins as defined above are followed by a successful login 
 
 ```yaml
 correlation:
-  type: temporal
+  type: temporal_ordered
   rules:
       - many_failed_logins
       - successful_login
   group-by:
       - User
   timespan: 1h
-  ordered: true
 ```
 
 Note:
@@ -497,7 +494,6 @@ correlation:
     - internal_ip
     - remote_ip
   timespan: 10s
-  ordered: true
   aliases:
     internal_ip:
       internal_error: destination.ip
@@ -637,14 +633,13 @@ references:
 author: Florian Roth (Nextron Systems)
 date: 2023/06/16
 correlation:
-   type: temporal
+   type: temporal_ordered
    rules:
       - multiple_failed_login
       - successful_login
    group-by:
     - User
    timespan: 10m
-   ordered: true
 falsepositives:
     - Unlikely
 level: high

--- a/appendix_meta_rules.md
+++ b/appendix_meta_rules.md
@@ -213,7 +213,7 @@ The following format must be used: `number + letter (in lowercase)`
 - Xd days
 
 
-<!-- TODO: Will we support a sum of the input values? Like 1h30m should be supported, shouldn't it? -->
+example for 1h30 : `timespan: 90m`
 
 ### Condition Selection
 

--- a/appendix_meta_rules.md
+++ b/appendix_meta_rules.md
@@ -133,7 +133,6 @@ Like sigma rules , correlation rules have a title and a unique id to identify th
 **Attribute:** title
 
 A brief title for the rule that should contain what the rule is supposed to detect (max. 256 characters)
-<!-- shouldn't it be mandatory ?-->
 
 ### Rule Identification  (optional)
 
@@ -240,17 +239,6 @@ It is a map of exactly one condition criterion:
 Example:
 ```yaml
 condition
-    gte: 100
-```
-
-**Subattribute:** field
-
-Used by value_count correlation to define the field name which values are counted.
-
-Example:
-```yaml
-condition
-    field: user
     gte: 100
 ```
 

--- a/meta-rule-schema.json
+++ b/meta-rule-schema.json
@@ -106,7 +106,8 @@
         "condition": {
           "type": "object",
           "description": "too fill",
-          "maxItems": 1,
+          "minItems": 1,
+          "maxItems": 2,
           "oneOf": [
             {
               "const": "gt",
@@ -129,9 +130,9 @@
               "type": "integer"
             },
             {
-              "const": "range",
-              "description": "The count must be in the given range specified as value in the format `min..max`",
-              "type": "string"
+              "const": "eq",
+              "description": "The count must be equal the given value",
+              "type": "integer"
             }
           ]
         }

--- a/meta-rule-schema.json
+++ b/meta-rule-schema.json
@@ -1,0 +1,98 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Sigma Meta rule specification V2.0.0 (2024/01/01)",
+    "type": "object",
+    "required": ["title","correlation"],
+    "properties": {
+      "title": {
+        "type": "string",
+        "maxLength": 256,
+        "description": "A brief title for the rule that should contain what the rules is supposed to detect"
+      },
+      "name": {
+        "type": "string",
+        "maxLength": 256,
+        "description": "A globally unique name for the Sigma rule"
+      },
+      "id": {
+        "type": "string",
+        "description": "A globally unique identifier for the Sigma rule. This is recommended to be a UUID v4, but not mandatory.",
+        "format": "uuid"
+      },
+      "level": {
+        "type": "string",
+        "description": "The criticality of a triggered rule",
+        "oneOf": [
+          {
+            "const": "informational",
+            "description": "Rule is intended for enrichment of events, e.g. by tagging them. No case or alerting should be triggered by such rules because it is expected that a huge amount of events will match these rules"
+          },
+          {
+            "const": "low",
+            "description": "Notable event but rarely an incident. Low rated events can be relevant in high numbers or combination with others. Immediate reaction shouldn't be necessary, but a regular review is recommended"
+          },
+          {
+            "const": "medium",
+            "description": "Relevant event that should be reviewed manually on a more frequent basis"
+          },
+          {
+            "const": "high",
+            "description": "Relevant event that should trigger an internal alert and requires a prompt review"
+          },
+          {
+            "const": "critical",
+            "description": "Highly relevant event that indicates an incident. Critical events should be reviewed immediately. It is used only for cases in which probability borders certainty"
+          }
+        ]
+      },
+      "correlation": {
+        "type": "object",
+        "required": ["type"],
+        "description": "too fill",
+        "properties": {
+          "type": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "to fill"
+          },
+          "rules": {
+            "type": "array",
+            "description": "to fill",
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "group-by": {
+            "type": "array",
+            "description": "to fill",
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "field": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "to fill"
+          },
+          "timespan": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "to fill"
+          },
+          "condition": {
+            "type": "object",
+            "description": "too fill",
+            "oneOf": [
+              {"const": "gt","description":"The count must be greater than the given value"},
+              {"const": "gte","description":"The count must be greater than or equal the given value"},
+              {"const": "lt","description":"The count must be lesser than the given value"},
+              {"const": "lte","description":"The count must be lesser than or equal the given value"},
+              {"const": "range","description":"The count must be in the given range specified as value in the format `min..max`"}
+            ]
+          }
+        }
+      }
+    }
+  }

--- a/meta-rule-schema.json
+++ b/meta-rule-schema.json
@@ -1,98 +1,141 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Sigma Meta rule specification V2.0.0 (2024/01/01)",
-    "type": "object",
-    "required": ["title","correlation"],
-    "properties": {
-      "title": {
-        "type": "string",
-        "maxLength": 256,
-        "description": "A brief title for the rule that should contain what the rules is supposed to detect"
-      },
-      "name": {
-        "type": "string",
-        "maxLength": 256,
-        "description": "A globally unique name for the Sigma rule"
-      },
-      "id": {
-        "type": "string",
-        "description": "A globally unique identifier for the Sigma rule. This is recommended to be a UUID v4, but not mandatory.",
-        "format": "uuid"
-      },
-      "level": {
-        "type": "string",
-        "description": "The criticality of a triggered rule",
-        "oneOf": [
-          {
-            "const": "informational",
-            "description": "Rule is intended for enrichment of events, e.g. by tagging them. No case or alerting should be triggered by such rules because it is expected that a huge amount of events will match these rules"
-          },
-          {
-            "const": "low",
-            "description": "Notable event but rarely an incident. Low rated events can be relevant in high numbers or combination with others. Immediate reaction shouldn't be necessary, but a regular review is recommended"
-          },
-          {
-            "const": "medium",
-            "description": "Relevant event that should be reviewed manually on a more frequent basis"
-          },
-          {
-            "const": "high",
-            "description": "Relevant event that should trigger an internal alert and requires a prompt review"
-          },
-          {
-            "const": "critical",
-            "description": "Highly relevant event that indicates an incident. Critical events should be reviewed immediately. It is used only for cases in which probability borders certainty"
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Sigma Meta rule specification V2.0.0 (2024/01/01)",
+  "type": "object",
+  "required": [
+    "title",
+    "correlation"
+  ],
+  "properties": {
+    "title": {
+      "type": "string",
+      "maxLength": 256,
+      "description": "A brief title for the rule that should contain what the rules is supposed to detect"
+    },
+    "name": {
+      "type": "string",
+      "maxLength": 256,
+      "description": "A globally unique name for the Sigma rule"
+    },
+    "id": {
+      "type": "string",
+      "description": "A globally unique identifier for the Sigma rule. This is recommended to be a UUID v4, but not mandatory.",
+      "format": "uuid"
+    },
+    "level": {
+      "type": "string",
+      "description": "The criticality of a triggered rule",
+      "oneOf": [
+        {
+          "const": "informational",
+          "description": "Rule is intended for enrichment of events, e.g. by tagging them. No case or alerting should be triggered by such rules because it is expected that a huge amount of events will match these rules"
+        },
+        {
+          "const": "low",
+          "description": "Notable event but rarely an incident. Low rated events can be relevant in high numbers or combination with others. Immediate reaction shouldn't be necessary, but a regular review is recommended"
+        },
+        {
+          "const": "medium",
+          "description": "Relevant event that should be reviewed manually on a more frequent basis"
+        },
+        {
+          "const": "high",
+          "description": "Relevant event that should trigger an internal alert and requires a prompt review"
+        },
+        {
+          "const": "critical",
+          "description": "Highly relevant event that indicates an incident. Critical events should be reviewed immediately. It is used only for cases in which probability borders certainty"
+        }
+      ]
+    },
+    "correlation": {
+      "type": "object",
+      "required": [
+        "type",
+        "rules",
+        "timespan"
+      ],
+      "description": "too fill",
+      "properties": {
+        "type": {
+          "type": "string",
+          "maxLength": 16,
+          "description": "Defines the corelation type",
+          "oneOf": [
+            {
+              "const": "event_count"
+            },
+            {
+              "const": "value_count"
+            },
+            {
+              "const": "temporal"
+            },
+            {
+              "const": "temporal_ordered"
+            }
+          ]
+        },
+        "rules": {
+          "type": "array",
+          "description": "to fill",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
           }
-        ]
-      },
-      "correlation": {
-        "type": "object",
-        "required": ["type"],
-        "description": "too fill",
-        "properties": {
-          "type": {
-            "type": "string",
-            "maxLength": 256,
-            "description": "to fill"
-          },
-          "rules": {
-            "type": "array",
-            "description": "to fill",
-            "uniqueItems": true,
-            "items": {
+        },
+        "group-by": {
+          "type": "array",
+          "description": "to fill",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "field": {
+          "type": "string",
+          "maxLength": 256,
+          "description": "to fill"
+        },
+        "timespan": {
+          "type": "string",
+          "maxLength": 256,
+          "description": "to fill"
+        },
+        "condition": {
+          "type": "object",
+          "description": "too fill",
+          "maxItems": 1,
+          "oneOf": [
+            {
+              "const": "gt",
+              "description": "The count must be greater than the given value",
+              "type": "integer"
+            },
+            {
+              "const": "gte",
+              "description": "The count must be greater than or equal the given value",
+              "type": "integer"
+            },
+            {
+              "const": "lt",
+              "description": "The count must be lesser than the given value",
+              "type": "integer"
+            },
+            {
+              "const": "lte",
+              "description": "The count must be lesser than or equal the given value",
+              "type": "integer"
+            },
+            {
+              "const": "range",
+              "description": "The count must be in the given range specified as value in the format `min..max`",
               "type": "string"
             }
-          },
-          "group-by": {
-            "type": "array",
-            "description": "to fill",
-            "uniqueItems": true,
-            "items": {
-              "type": "string"
-            }
-          },
-          "field": {
-            "type": "string",
-            "maxLength": 256,
-            "description": "to fill"
-          },
-          "timespan": {
-            "type": "string",
-            "maxLength": 256,
-            "description": "to fill"
-          },
-          "condition": {
-            "type": "object",
-            "description": "too fill",
-            "oneOf": [
-              {"const": "gt","description":"The count must be greater than the given value"},
-              {"const": "gte","description":"The count must be greater than or equal the given value"},
-              {"const": "lt","description":"The count must be lesser than the given value"},
-              {"const": "lte","description":"The count must be lesser than or equal the given value"},
-              {"const": "range","description":"The count must be in the given range specified as value in the format `min..max`"}
-            ]
-          }
+          ]
         }
       }
     }
   }
+}


### PR DESCRIPTION
Warning This PR is only for the Correlation rules section.

The meta-rule-schema.json file in progress 

- Small text cleanup 
- Remove useless ordered boolean
- Remove `generate` move to [discussion](https://github.com/SigmaHQ/sigma-specification/discussions/113)
- discussion [V2.0.0 Meta-rule Time Selection ](https://github.com/SigmaHQ/sigma-specification/discussions/116)