### PR TITLE
[v2] Updates Sigma Meta Filters: Renaming `global_filter` to `filter` 

### DIFF
--- a/Sigma_meta_filter.md
+++ b/Sigma_meta_filter.md
@@ -1,4 +1,4 @@
-# Sigma Meta Filter <!-- omit in toc -->
+# Sigma Filter <!-- omit in toc -->
 
 The following document defines the standardized global filter that can be used with Sigma rules.
 
@@ -108,7 +108,7 @@ See log source in [sigma specification](Sigma_specification.md)
 
 ### Global Filter
 
-**Attribute**: global_filter
+**Attribute**: filter
 
 
 ### Relative rules
@@ -134,7 +134,7 @@ description: The valid administrator account start with adm_
 logsource:
     category: process_creation
     product: windows
-global_filter:
+filter:
   rules:
     - 6f3e2987-db24-4c78-a860-b4f4095a7095 # Data Compressed - rar.exe
     - df0841c0-9846-4e9f-ad8a-7df91571771b # Login on jump host

--- a/V2_changes.md
+++ b/V2_changes.md
@@ -20,8 +20,8 @@ Version 2 only use ISO 8601 with separator format : YYYY-MM-DD
 
 # Correlation
 
-- Remove aggregation expression in Sigma rule file see [Sigma meta rules](/Sigma_meta_rules.md)
+- Remove aggregation expression in Sigma rule file, see [Sigma meta rules](/Sigma_meta_rules.md)
 
 # Global filter
 
-- Adds the ability to make global filters see [Sigma meta filter](/Sigma_meta_filter.md)
+- Adds the ability to make filter rule files, see [Sigma meta filter](/Sigma_meta_filter.md)

--- a/schema/meta-filter-schema.json
+++ b/schema/meta-filter-schema.json
@@ -5,7 +5,7 @@
   "required": [
     "title",
     "logsource",
-    "global_filter"
+    "filter"
   ],
   "properties": {
     "title": {
@@ -51,7 +51,7 @@
         }
       }
     },
-    "global_filter": {
+    "filter": {
       "type": "object",
       "required": ["rules","condition"],
       "description": "A set of search-identifiers that represent properties of searches on log data",


### PR DESCRIPTION
This PR updates the Sigma specification to rename the 'global_filter' attribute to simply 'filter' in Sigma Meta Filter files.

## Key changes:

- Renamed `global_filter` to `filter` in Sigma_meta_filter.md
- Updated V2_changes.md to reflect the new terminology
- Modified schema/meta-filter-schema.json to use `filter` instead of `global_filter`