### PR TITLE
update modifiers appendix

### DIFF
--- a/appendix/sigma-modifiers-appendix.md
+++ b/appendix/sigma-modifiers-appendix.md
@@ -94,7 +94,7 @@ The modifiers listed in this section can only be applied to numeric values.
 
 The modifiers listed in this section can only applied to IP values.
 
-* `cidr`: The value is handled as an CIDR by backends. Supports both IPv4 and IPv6 notations.
+* `cidr`: The value is handled as an CIDR by backends. Supports both IPv4 and IPv6 notations. Example: `DestinationIp|cidr: 10.0.0.0/8`
 
 ### Specific Modifiers
 

--- a/appendix/sigma-modifiers-appendix.md
+++ b/appendix/sigma-modifiers-appendix.md
@@ -3,7 +3,7 @@
 The following document defines the standardized modifiers that can be used in Sigma.
 
 * Version 2.0.1
-* Release date 2024-08-08
+* Release date 2024-08-10
 
 ### Summary
 
@@ -87,7 +87,7 @@ The following modifiers are only applied to IP fields.
 
 ## History
 
-* 2024-08-10 Modifiers Appendix v2.0.0
+* 2024-08-10 Modifiers Appendix v2.0.1
 * 2024-08-08 Modifiers Appendix v2.0.0
 * 2023-05-27 Modifiers Appendix v1.0.4
   * Update from PySigma 0.7.6

--- a/appendix/sigma-modifiers-appendix.md
+++ b/appendix/sigma-modifiers-appendix.md
@@ -63,7 +63,7 @@ The modifiers listed in this section can only be applied to string values.
 
 
 * `re` sub-modifiers:
-  * `i`: (insensitive) to enable case-sensitive matching.
+  * `i`: (insensitive) to enable case-insensitive matching.
   * `m`: (multi line) to match across multiple lines. `^` /`$` match the start/end of line.
   * `s`: (single line) to enable that dot (`.`) matches all characters, including the newline character.
 

--- a/appendix/sigma-modifiers-appendix.md
+++ b/appendix/sigma-modifiers-appendix.md
@@ -1,21 +1,23 @@
-# Modifiers <!-- omit in toc -->
+# Sigma Modifiers <!-- omit in toc -->
 
 The following document defines the standardized modifiers that can be used in Sigma.
 
-* Version 2.0.0
+* Version 2.0.1
 * Release date 2024-08-08
 
-## Summary
-- [Summary](#summary)
-- [General](#general)
-  - [String only](#string-only)
-  - [Numeric only](#numeric-only)
-  - [Ip only](#ip-only)
+### Summary
+
+- [Generic](#generic)
+- [String](#string)
   - [String Encoding](#string-encoding)
+- [Numeric](#numeric)
+- [IP (Internet  Protocol)](#ip-internet-protocol)
 - [Specific](#specific)
 - [History](#history)
 
-## General
+### Generic
+
+The following modifiers are considered generic modifiers and can be applied on all types of fields.
 
 * `all`: Normally, lists of values are linked with *OR* in the generated query. This modifier
   changes this to *AND*. This is useful if you want to express a command line invocation with different
@@ -32,7 +34,9 @@ The following document defines the standardized modifiers that can be used in Si
 * `exists`: Defines that a certain field has to exist or must not exist in a log event by providing a boolean value. Note that this check only verifies the presence of a field, not its value, be it empty or null.
 * `cased`: Values are applied case sensitively. Default Sigma behavior is case-insensitive matching.
 
-### String only
+### String 
+
+The following modifiers can only be applied to strings.
 
 * `windash`: Creates all possible permutations of the `-`, `/`, `–` (en dash), `—` (em dash), and `―` (horizontal bar) characters. Windows command line flags can often be indicated by both characters. Using the `windash` modifier converts the aforementioned characters interchangeably and uses all possible permutation of strings in the selection.
 
@@ -42,18 +46,7 @@ The following document defines the standardized modifiers that can be used in Si
   * `m`: (multi line) to match across multiple lines. `^` /`$` match the start/end of line.
   * `s`: (single line) to enable that dot (`.`) matches all characters, including the newline character.
 
-### Numeric only
-
-* `lt`: Field is less than the value
-* `lte`: Field is less or equal than the value
-* `gt`: Field is greater than the value
-* `gte`: Field is greater or equal than the value
-
-### Ip only
-  
-* `cidr`: The value is handled as an CIDR by backends. Supports both IPv4 and IPv6 notations.
-
-### String Encoding
+#### String Encoding
 
 * `base64`: The value is encoded with Base64.
 * `base64offset`: If a value might appear somewhere in a base64-encoded string the representation
@@ -65,6 +58,22 @@ The following document defines the standardized modifiers that can be used in Si
   * `utf16le`: Transforms value to UTF16-LE encoding, e.g. `cmd` > `63 00 6d 00 64 00` 
   * `utf16be`: Transforms value to UTF16-BE encoding, e.g. `cmd` > `00 63 00 6d 00 64`
   * `utf16`: Prepends a [byte order mark](https://en.wikipedia.org/wiki/Byte_order_mark) and encodes UTF16, e.g. `cmd` > `FF FE 63 00 6d 00 64 00`
+  * `wide`: an alias for the `utf16le` modifier.
+
+### Numeric
+
+The following modifiers can only be applied to numeric values.
+
+* `lt`: Field is less than the value
+* `lte`: Field is less or equal than the value
+* `gt`: Field is greater than the value
+* `gte`: Field is greater or equal than the value
+
+### IP (Internet Protocol)
+
+The following modifiers are only applied to IP fields.
+  
+* `cidr`: The value is handled as an CIDR by backends. Supports both IPv4 and IPv6 notations.
 
 ## Specific
 
@@ -78,6 +87,7 @@ The following document defines the standardized modifiers that can be used in Si
 
 ## History
 
+* 2024-08-10 Modifiers Appendix v2.0.0
 * 2024-08-08 Modifiers Appendix v2.0.0
 * 2023-05-27 Modifiers Appendix v1.0.4
   * Update from PySigma 0.7.6

--- a/appendix/sigma-modifiers-appendix.md
+++ b/appendix/sigma-modifiers-appendix.md
@@ -5,24 +5,26 @@ The following document defines the standardized modifiers that can be used in Si
 * Version 2.0.1
 * Release date 2024-08-10
 
-### Summary
+## Summary
 
-- [Generic](#generic)
-- [String](#string)
-  - [String Encoding](#string-encoding)
-- [Numeric](#numeric)
-- [IP (Internet  Protocol)](#ip-internet-protocol)
-- [Specific](#specific)
+- [Summary](#summary)
+  - [Generic Modifiers](#generic-modifiers)
+  - [String Modifiers](#string-modifiers)
+    - [Regular Expression](#regular-expression)
+    - [Encoding](#encoding)
+  - [Numeric Modifiers](#numeric-modifiers)
+  - [IP (Internet Protocol) Modifiers](#ip-internet-protocol-modifiers)
+  - [Specific Modifiers](#specific-modifiers)
 - [History](#history)
 
-### Generic
+### Generic Modifiers
 
 The following modifiers are considered generic modifiers and can be applied on all types of fields.
 
 * `all`: Normally, lists of values are linked with *OR* in the generated query. This modifier
   changes this to *AND*. This is useful if you want to express a command line invocation with different
   parameters where the order may vary and removes the need for some cumbersome workarounds.
-  
+
   Single item values are not allowed to have an `all` modifier as some back-ends cannot support it.
   If you use it as a workaround to duplicate a field in a selection, use a new selection instead.
 
@@ -34,19 +36,38 @@ The following modifiers are considered generic modifiers and can be applied on a
 * `exists`: Defines that a certain field has to exist or must not exist in a log event by providing a boolean value. Note that this check only verifies the presence of a field, not its value, be it empty or null.
 * `cased`: Values are applied case sensitively. Default Sigma behavior is case-insensitive matching.
 
-### String 
+### String Modifiers
 
-The following modifiers can only be applied to strings.
+The modifiers listed in this section can only be applied to string values.
 
 * `windash`: Creates all possible permutations of the `-`, `/`, `–` (en dash), `—` (em dash), and `―` (horizontal bar) characters. Windows command line flags can often be indicated by both characters. Using the `windash` modifier converts the aforementioned characters interchangeably and uses all possible permutation of strings in the selection.
 
-* `re`: Value is handled as a regular expression by backends. Regex is matched case-sensitive by default
+#### Regular Expression
+
+* `re`: Value is handled as a regular expression by backends. Regex is matched case-sensitive by default.
+  * Currently the supported flavor is PCRE with the following metacharacters:
+    * Wildcards: `.`.
+    * Anchors: `^`, `$`.
+    * Quantifiers: `*`, `+`, `?`, `{n,m}`.
+    * Character Classes: [a-z], [^a-z].
+    * Grouping and Capturing: `()`.
+    * Alternation: `|`.
+  * The following metacharacters are unsupported:
+    * Character Classes: `[[:digit:]]`
+    * Lookahead Assertions:
+      * Positive Lookahead: `(?=...)`
+      * Negative Lookahead: `(?!...)`
+      * Positive Lookbehind: `(?<=...)`
+      * Negative Lookbehind: `(?<!...)`
+    * Atomic Grouping: `(?>`
+
+
 * `re` sub-modifiers:
   * `i`: (insensitive) to enable case-sensitive matching.
   * `m`: (multi line) to match across multiple lines. `^` /`$` match the start/end of line.
   * `s`: (single line) to enable that dot (`.`) matches all characters, including the newline character.
 
-#### String Encoding
+#### Encoding
 
 * `base64`: The value is encoded with Base64.
 * `base64offset`: If a value might appear somewhere in a base64-encoded string the representation
@@ -55,27 +76,27 @@ The following modifiers can only be applied to strings.
   the middle that can be recognized.
 
 * `base64` sub-modifiers:
-  * `utf16le`: Transforms value to UTF16-LE encoding, e.g. `cmd` > `63 00 6d 00 64 00` 
+  * `utf16le`: Transforms value to UTF16-LE encoding, e.g. `cmd` > `63 00 6d 00 64 00`
   * `utf16be`: Transforms value to UTF16-BE encoding, e.g. `cmd` > `00 63 00 6d 00 64`
   * `utf16`: Prepends a [byte order mark](https://en.wikipedia.org/wiki/Byte_order_mark) and encodes UTF16, e.g. `cmd` > `FF FE 63 00 6d 00 64 00`
   * `wide`: an alias for the `utf16le` modifier.
 
-### Numeric
+### Numeric Modifiers
 
-The following modifiers can only be applied to numeric values.
+The modifiers listed in this section can only be applied to numeric values.
 
 * `lt`: Field is less than the value
 * `lte`: Field is less or equal than the value
 * `gt`: Field is greater than the value
 * `gte`: Field is greater or equal than the value
 
-### IP (Internet Protocol)
+### IP (Internet Protocol) Modifiers
 
-The following modifiers are only applied to IP fields.
-  
+The modifiers listed in this section can only applied to IP values.
+
 * `cidr`: The value is handled as an CIDR by backends. Supports both IPv4 and IPv6 notations.
 
-## Specific
+### Specific Modifiers
 
 * `expand`: Modifier for expansion of placeholders in values. The final behavior of the replacement is determined by processing pipeline transformations. Current possibilities in pySigma are:
   * Expand to value list (`ValueListPlaceholderTransformation`/`value_placeholders`)
@@ -88,6 +109,8 @@ The following modifiers are only applied to IP fields.
 ## History
 
 * 2024-08-10 Modifiers Appendix v2.0.1
+  * Add regular expression flavor definition.
+  * restructure titles
 * 2024-08-08 Modifiers Appendix v2.0.0
 * 2023-05-27 Modifiers Appendix v1.0.4
   * Update from PySigma 0.7.6

--- a/appendix/sigma-tags-appendix.md
+++ b/appendix/sigma-tags-appendix.md
@@ -1,9 +1,9 @@
-# Sigma Tags <!-- omit in toc -->
+# Tags <!-- omit in toc -->
 
 The following document defines the standardized tags that can be used to categorize the different Sigma rules.
 
-* Version 2.0.1
-* Release date 2024-08-11
+* Version 2.0.0
+* Release date 2024-08-08
 
 ## Summary
 
@@ -99,8 +99,6 @@ The following tags are currently supported:
 
 ## History
 
-* 2024-08-11 Tags Appendix v2.0.1
-  * Update document title
 * 2024-08-08 Tags Appendix v2.0.0
 * 2023-11-23 Tags Appendix v1.2.0
   * Add Summiting the Pyramid

--- a/appendix/sigma-tags-appendix.md
+++ b/appendix/sigma-tags-appendix.md
@@ -1,9 +1,9 @@
-# Tags <!-- omit in toc -->
+# Sigma Tags <!-- omit in toc -->
 
 The following document defines the standardized tags that can be used to categorize the different Sigma rules.
 
-* Version 2.0.0
-* Release date 2024-08-08
+* Version 2.0.1
+* Release date 2024-08-11
 
 ## Summary
 
@@ -99,6 +99,8 @@ The following tags are currently supported:
 
 ## History
 
+* 2024-08-11 Tags Appendix v2.0.1
+  * Update document title
 * 2024-08-08 Tags Appendix v2.0.0
 * 2023-11-23 Tags Appendix v1.2.0
   * Add Summiting the Pyramid


### PR DESCRIPTION
- Updated the modifiers appendix with better titles and small description for each section.
- Added a new section to the `re` modifier to define the supported regex falvor and metacharacters.