### PR TITLE
update correlation json schema and specs formatting

### DIFF
--- a/json-schema/sigma-correlation-rules-schema.json
+++ b/json-schema/sigma-correlation-rules-schema.json
@@ -10,7 +10,7 @@
     "title": {
       "type": "string",
       "maxLength": 256,
-      "description": "A brief title for the rule that should contain what the rules is supposed to detect"
+      "description": "A brief title for the rule that should contain what the rule is supposed to detect"
     },
     "id": {
       "type": "string",
@@ -52,35 +52,35 @@
         "timespan",
         "condition"
       ],
-      "description": "represents the correlation searched for on the log data",
+      "description": "Represents the correlation searched for on the log data",
       "properties": {
         "type": {
           "type": "string",
           "maxLength": 16,
-          "description": "Defines the corelation type",
+          "description": "Defines the correlation type",
           "oneOf": [
             {
               "const": "event_count"
-            },
-            {
-              "const": "value_count"
             },
             {
               "const": "temporal"
             },
             {
               "const": "temporal_ordered"
+            },
+            {
+              "const": "value_count"
             }
           ]
         },
-        "rules":{
+        "rules": {
           "description": "Refers to one or multiple Sigma or Correlations rules",
           "uniqueItems": true,
           "anyOf": [
             {
               "type": "array",
               "items": {
-                "anyOf":[
+                "anyOf": [
                   {
                     "type": "string",
                     "minLength": 2
@@ -90,15 +90,14 @@
                     "format": "uuid"
                   }
                 ]
-
               }
             }
           ]
         },
-        "alias":{
+        "alias": {
           "type": "object",
-          "description": "defines field name aliases that are applied to correlated Sigma rules",
-          "additionalProperties":{
+          "description": "Defines field name aliases that are applied to correlated Sigma rules",
+          "additionalProperties": {
             "anyOf": [
               {
                 "type": "object",
@@ -111,7 +110,7 @@
         },
         "group-by": {
           "type": "array",
-          "description": "defines one or multiple fields which should be treated as separate event occurrence scope",
+          "description": "Defines one or multiple fields which should be treated as separate event occurrence scope",
           "uniqueItems": true,
           "items": {
             "type": "string"
@@ -120,7 +119,7 @@
         "timespan": {
           "type": "string",
           "maxLength": 10,
-          "description": "defines a time period in which the correlation should be applied. used: `number + letter (in lowercase)`"
+          "description": "Defines a time period in which the correlation should be applied. Used: `number + letter (in lowercase)`"
         },
         "condition": {
           "type": "object",
@@ -137,7 +136,7 @@
             },
             {
               "gte": {
-                "description": "The count must be greater than or equal the given value",
+                "description": "The count must be greater than or equal to the given value",
                 "type": "integer"
               }
             },
@@ -149,26 +148,44 @@
             },
             {
               "lte": {
-                "description": "The count must be lesser than or equal the given value",
+                "description": "The count must be lesser than or equal to the given value",
                 "type": "integer"
               }
             },
             {
               "eq": {
-                "description": "The count must be equal the given value",
+                "description": "The count must be equal to the given value",
                 "type": "integer"
               }
             },
             {
               "field": {
-                "description": "name of the field to counts values",
+                "description": "Name of the field to count values",
                 "type": "string",
                 "maxLength": 256
               }
             }
           ]
         }
-      }
+      },
+      "allOf": [
+        {
+        "if": { "properties": {"type": {"const": "event_count"}}},
+        "then": {"required": ["condition", "group-by", "timespan"]}
+        },
+        {
+        "if": { "properties": {"type": {"const": "temporal"}}},
+        "then": {"required": ["group-by", "timespan"]}
+        },
+        {
+        "if": { "properties": {"type": {"const": "temporal_ordered"}}},
+        "then": {"required": ["group-by", "timespan"]}
+        },
+        {
+        "if": { "properties": {"type": {"const": "value_count"}}},
+        "then": {"required": ["condition", "field", "group-by", "timespan"]}
+        }
+      ]
     },
     "level": {
       "type": "string",
@@ -180,7 +197,7 @@
         },
         {
           "const": "low",
-          "description": "Notable event but rarely an incident. Low rated events can be relevant in high numbers or combination with others. Immediate reaction shouldn't be necessary, but a regular review is recommended"
+          "description": "Notable event but rarely an incident. Low-rated events can be relevant in high numbers or in combination with others. Immediate reaction shouldn't be necessary, but a regular review is recommended"
         },
         {
           "const": "medium",
@@ -198,7 +215,7 @@
     },
     "generate": {
       "type": "boolean",
-      "description": "defines if the rules referred from the correlation rule should be converted as stand-alone rules"
+      "description": "Defines if the rules referred to by the correlation rule should be converted into stand-alone rules"
     }
   }
 }

--- a/specification/sigma-correlation-rules-specification.md
+++ b/specification/sigma-correlation-rules-specification.md
@@ -42,12 +42,12 @@ The following document defines the standardized correlation that can be used in 
   - [Failed Logins Followed by Successful Login](#failed-logins-followed-by-successful-login)
 - [History](#history)
 
-# Introduction
+## Introduction
 
 Sometimes you need more advanced searches than simple selections.
 For this purpose, you can use meta-rules that correlate multiple Sigma rules.
 
-## Compatibility
+### Compatibility
 
 When generating a backend specific query, Sigma correlations might exceed the capabilities of that targeted backend. \
 Or the Sigma correlation might require a feature that is only supported partially by the target backend. \
@@ -70,7 +70,7 @@ Examples are:
 * Temporal relationships are recognized, but the order of the events cannot be recognized by the target system. This could cause false positives by differently ordered events.
 * Temporal relationships are only recognized within static time boundaries, e.g. a `timespan` of 1h only matches if all events appear within a full hour, but not if some events appear in the previous and another event in the current hour. This could cause false negatives.
 
-## Expression of Relationships In The Condition of Sigma Rules
+### Expression of Relationships In The Condition of Sigma Rules
 
 This was the first approach defined in Sigma with aggregations and the near operator and is now obsolete. \
 Sigma correlations are not based on this approach for the following reasons:
@@ -80,7 +80,7 @@ Sigma correlations are not based on this approach for the following reasons:
 * One of the goals of Sigma rules was to keep the condition logic simple. Especially the specification of temporal relationships can get quite complex in a query expression. Specifying correlation chains adds further complexity.
 * The pipe syntax sometimes caused the rule contributors to consider it as a Splunk query or another target system-specific query language. Expressing these relationships in a “Sigmaish” way should not cause these associations.
 
-## Type of Correlation rules
+### Type of Correlation rules
 
 The purpose is to cover a detection like:
 
@@ -88,37 +88,36 @@ The purpose is to cover a detection like:
 * Invalid login alert on the same host but from X remote.
 * Alert A, B and C in the same `timespan`.
 
-
-# Correlation rules
+## Correlation rules
 
 The rules in a multi-document YAML that build a correlation rule are not producing individual, independent queries. They are used as a tool to define more complex constructs out of basic Sigma detections. Therefore only the outermost correlation rule may define meta information such as status, level, date or anything else.
 
-## File Structure
-### YAML File
+### File Structure
+
+#### YAML File
 
 To keep the file names interoperable use the following:
 
-- Length between 10 and 70 characters
-- Lowercase
-- No special characters, only letters (a-z) and digits (0-9)
-- Use `_` instead of a space
-- Use `.yml` as a file extension
+* Length between 10 and 70 characters
+* Lowercase
+* No special characters, only letters (a-z) and digits (0-9)
+* Use `_` instead of a space
+* Use `.yml` as a file extension
 
 As a best practice use the prefix `mr_`.
 
-
-### Schema
+#### Schema
 
 [Sigma Correlation Rules JSON Schema](/json-schema/sigma-correlation-rules-schema.json)
 
-###  Syntax
+#### Syntax
 
 A Sigma correlation is a dedicated YAML document.
 Like Sigma rules , correlation rules have a title and a unique id to identify them.
 
-## Components
+### Components
 
-### Title
+#### Title
 
 **Attribute:** title
 
@@ -126,7 +125,7 @@ Like Sigma rules , correlation rules have a title and a unique id to identify th
 
 A brief title for the rule that should contain what the rule is supposed to detect (max. 256 characters)
 
-### Identification
+#### Identification
 
 **Attribute:** id
 
@@ -142,7 +141,7 @@ title: login brute force
 id: 0e95725d-7320-415d-80f7-004da920fc11
 ```
 
-### Description
+#### Description
 
 **Attribute:** description
 
@@ -150,7 +149,7 @@ id: 0e95725d-7320-415d-80f7-004da920fc11
 
 A short description of the rule and the malicious activity that can be detected (max. 65,535 characters)
 
-### Author
+#### Author
 
 **Attribute**: author
 
@@ -158,7 +157,7 @@ A short description of the rule and the malicious activity that can be detected 
 
 Creator of the rule. (can be a name, nickname, twitter handle...etc)
 
-### References
+#### References
 
 **Attribute**: reference
 
@@ -167,7 +166,7 @@ Creator of the rule. (can be a name, nickname, twitter handle...etc)
 References to the source that the rule was derived from. \
 These could be blog articles, technical papers, presentations or even tweets.
 
-### Date
+#### Date
 
 **Attribute**: date
 
@@ -176,7 +175,7 @@ These could be blog articles, technical papers, presentations or even tweets.
 Creation date of the meta rule. \
 Use the ISO 8601 date with separator format: `YYYY-MM-DD`
 
-### Modified
+#### Modified
 
 **Attribute**: modified
 
@@ -185,21 +184,22 @@ Use the ISO 8601 date with separator format: `YYYY-MM-DD`
 *Last* modification date of the meta rule. \
 Use the ISO 8601 date with separator format : `YYYY-MM-DD`
 
-### Correlation section
+#### Correlation section
 
-#### Correlation type
+##### Correlation type
 
 **Attribute:** type
 
 **Use:** mandatory
 
-Can be :
-- event_count
-- value_count
-- temporal
-- temporal_ordered
+Allowed values:
 
-#### Related rules
+* event_count
+* value_count
+* temporal
+* temporal_ordered
+
+##### Related rules
 
 **Attribute:** rules
 
@@ -221,7 +221,7 @@ correlation:
     - firewall_block  # The internal tools have a lookup table to the correct rule `id` by `name`
 ```
 
-#### Aliases
+##### Aliases
 
 **Attribute:** aliases
 
@@ -232,17 +232,18 @@ The defined aliases can then be defined in `group-by` and allows aggregation acr
 
 See the example in the chapter [Field Name Aliases](#field-name-aliases) to get a better understanding.
 
-#### Grouping
+##### Grouping
 
 **Attribute:** group-by
 
 **Use:** mandatory
 
 optionally defines one or multiple fields which should be treated as separate event occurrence scope. Examples:
-  * count events by user
-  * temporal proximity must occur on one system by the same user
 
-#### Time Selection
+* count events by user
+* temporal proximity must occur on one system by the same user
+
+##### Time Selection
 
 **Attribute:** timespan
 
@@ -250,14 +251,15 @@ optionally defines one or multiple fields which should be treated as separate ev
 
 defines a time period in which the correlation should be applied.
 The following format must be used: `number + letter (in lowercase)`
-- Xs seconds
-- Xm minutes
-- Xh hours
-- Xd days
+
+* Xs seconds
+* Xm minutes
+* Xh hours
+* Xd days
 
 example for 1h30 : `timespan: 90m`
 
-#### Condition
+##### Condition
 
 **Attribute:** condition
 
@@ -294,10 +296,10 @@ condition:
     lte: 200
 ```
 
-If you need more complex constructs, you can always chain correlation rules together.  
+If you need more complex constructs, you can always chain correlation rules together.
 See the examples at the far bottom, for more details.
 
-### Level
+#### Level
 
 **Attribute:**  level
 
@@ -306,7 +308,7 @@ See the examples at the far bottom, for more details.
 defines a severity level adjustment if the correlation matches.
 This allows to give single event hits a low or informational severity and increasing this to higher levels in case of correlating appearances of events.
 
-### Generate
+#### Generate
 
 **Attribute:** generate
 
@@ -315,14 +317,15 @@ This allows to give single event hits a low or informational severity and increa
 defines if the rules referred from the correlation rule should be converted
 as stand-alone rules or if only the correlation query should be generated (default).
 
-## Correlation Types
-### Event Count (event_count)
+### Correlation Types
+
+#### Event Count (event_count)
 
 Counts events occurring in the given time frame specified by the referred Sigma rule or rules.
 The resulting query must count events for each group specified by group-by separately.
 The condition finally defines how many events must occur to generate a search hit.
 
-Requires : 
+Requires :
  - `group-by`
  - `timespan`
  - `condition`
@@ -343,7 +346,7 @@ correlation:
         gte: 100
 ```
 
-### Value Count (value_count)
+#### Value Count (value_count)
 
 Counts values in a field defined by `field`.
 The resulting query must count field values separately for each group specified by group-by.
@@ -373,7 +376,7 @@ correlation:
         gte: 100
 ```
 
-### Temporal Proximity (temporal)
+#### Temporal Proximity (temporal)
 
 All events defined by the rules referred by the rule field must occur in the time frame defined by timespan.
 The values of fields defined in group-by must all have the same value (e.g. the same host or user).
@@ -395,7 +398,7 @@ type: temporal
     timespan: 5m
 ```
 
-### Ordered Temporal Proximity (temporal_ordered)
+#### Ordered Temporal Proximity (temporal_ordered)
 
 The *temporal_ordered* correlation type behaves like *temporal* and requires in addition that the events appear in the
 order provided in the *rule* attribute.
@@ -416,7 +419,7 @@ correlation:
 Note:
 Even if the rule many_failed_logins groups by the "ComputerName" field, the correlation rule only uses its own `group-by` "User".
 
-## Field Name Aliases
+### Field Name Aliases
 
 Sometimes correlation of values in the same fields is not sufficient. E.g. a correlation rule might require to aggregate events that appear from a source address in one event and the same address as destination in another event. A Sigma correlation rule can contain an `aliases` attribute that defines an alias for different field names in events matched by different Sigma rules. The alias field names can then be referenced in `group-by` attributes and are resolved to their respective field names.
 
@@ -434,7 +437,7 @@ The field names referenced in aliases must not necessarily appear in the Sigma r
 `<Sigma rule name>` is the name given by the `name` attribute. \
 The `name` attribute is optional in general, but has to be defined, if you want to use `aliases`.
 
-### Field Name Aliases Example
+#### Field Name Aliases Example
 
 The following correlation rule defines field name aliases `internal_ip` and `remote_ip` that are used in the `group-by` attribute. \
 The `internal_ip` alias references the field `destination.ip` in the events matched by the Sigma rule `internal_error` and `source.ip` in the events matched by the Sigma rule `new_network_connection`. \
@@ -484,15 +487,17 @@ correlation:
             new_network_connection: destination.ip
 ```
 
-# Examples
+## Examples
+
 This section gives complete examples in order to make it easier for people new to Sigma to get started and for showcasing new features of the Sigma standard. Use them as a blueprint for your own ideas.
 
-## Failed Logins Followed by Successful Login
+### Failed Logins Followed by Successful Login
 
 The following Correlation describes a use case in which an attacker successfully performs a brute-force attack. This example helps in showcasing some highlights:
- - You can use YAMLs multi document feature (`---`) to have everything grouped together in one file
- - Rules can be referenced in a human-friendly way using their unique `name`.
- - Correlations can be chained to express more complex use cases
+
+* You can use YAMLs multi document feature (`---`) to have everything grouped together in one file
+* Rules can be referenced in a human-friendly way using their unique `name`.
+* Correlations can be chained to express more complex use cases
 
 ```yml
 title: Correlation - Multiple Failed Logins Followed by Successful Login
@@ -557,6 +562,6 @@ detection:
     condition: selection
 ```
 
-# History
+## History
 
 * 2024-08-08 Specification v2.0.0

--- a/specification/sigma-filters-specification.md
+++ b/specification/sigma-filters-specification.md
@@ -25,45 +25,41 @@ The following document defines the standardized global filter that can be used w
 - [Examples](#examples)
 - [History](#history)
 
-
-# Introduction
+## Introduction
 
 The purpose of Filter rules is to apply the same tuning on many rules with the goal to suppress matches of multiple rules. This is most commonly useful for environment specific tuning where a false positive prone application is used in an organization and its false positives are accepted.
 
 Example: A valid GPO script that triggers multiple Sigma rules.
 
-# Global filter
+## Global filter
 
-## File Structure
+### File Structure
 
-### YAML File
+#### YAML File
 
 To keep the file names interoperable use the following:
 
-- Length between 10 and 70 characters
-- Lowercase
-- No special characters only letters (a-z) and digits (0-9)
-- Use `_` instead of a space
-- Use `.yml` as a file extension
+* Length between 10 and 70 characters
+* Lowercase
+* No special characters only letters (a-z) and digits (0-9)
+* Use `_` instead of a space
+* Use `.yml` as a file extension
 
 As a best practice use the prefix `mf_`
 
-
-### Schema
+#### Schema
 
 [Sigma Filters JSON Schema](/json-schema/sigma-filters-schema.json)
 
-
-### Syntax
+#### Syntax
 
 A Sigma global filter is a dedicated YAML document.
 Like Sigma rules, "Filter" rules have a `title` and a unique `id` to identify them.
 It has no `level` or `status` because its purpose is to enrich an existing Sigma rule.
 
+### Components
 
-## Components
-
-### title
+#### title
 
 **Attribute:** title
 
@@ -71,7 +67,7 @@ It has no `level` or `status` because its purpose is to enrich an existing Sigma
 
 A brief title for the rule that should contain what the rule is supposed to detect (max. 256 characters)
 
-### Identification
+#### Identification
 
 **Attribute:** id
 
@@ -87,7 +83,7 @@ title: login brute force
 id: 0e95725d-7320-415d-80f7-004da920fc11
 ```
 
-### Description
+#### Description
 
 **Attribute:** description
 
@@ -95,7 +91,7 @@ id: 0e95725d-7320-415d-80f7-004da920fc11
 
 A short description of the rule and the malicious activity that can be detected (max. 65,535 characters)
 
-### Date
+#### Date
 
 **Attribute**: date
 
@@ -104,7 +100,7 @@ A short description of the rule and the malicious activity that can be detected 
 Creation date of the meta filter. \
 Use the ISO 8601 date with separator format : YYYY-MM-DD
 
-### Modified
+#### Modified
 
 **Attribute**: modified
 
@@ -113,7 +109,7 @@ Use the ISO 8601 date with separator format : YYYY-MM-DD
 *Last* modification date of the meta filter. \
 Use the ISO 8601 date with separator format : YYYY-MM-DD
 
-### Log source
+#### Log source
 
 **Attribute**: logsource
 
@@ -121,14 +117,13 @@ Use the ISO 8601 date with separator format : YYYY-MM-DD
 
 Read more on the `logsource` attribute in the [Sigma Rules Specification](/specification/sigma-rules-specification.md)
 
-
-### Global Filter
+#### Global Filter
 
 **Attribute**: filter
 
 **Use:** mandatory
 
-#### Relative rules
+##### Relative rules
 
 **Attribute:** rules
 
@@ -136,8 +131,7 @@ Read more on the `logsource` attribute in the [Sigma Rules Specification](/speci
 
 refers to one or multiple Sigma rules where to add the filter
 
-
-#### filter selection
+##### filter selection
 
 **Attribute**: selection
 
@@ -145,7 +139,7 @@ refers to one or multiple Sigma rules where to add the filter
 
 Read more on the 'detection' section in the [Sigma Rules Specification](/specification/sigma-rules-specification.md)
 
-#### filter condition
+##### filter condition
 
 **Attribute**: condition
 
@@ -153,7 +147,7 @@ Read more on the 'detection' section in the [Sigma Rules Specification](/specifi
 
 Read more on the 'detection' field in the [Sigma Rules Specification](/specification/sigma-rules-specification.md)
 
-# Examples
+## Examples
 
 This section gives complete examples in order to make it easier for people new to Sigma to get started and for showcasing new features of the Sigma standard. Use them as a blueprint for your own ideas.
 
@@ -172,6 +166,6 @@ filter:
     condition: selection
 ```
 
-# History
+## History
 
 * 2024-08-08 Specification v2.0.0

--- a/specification/sigma-rules-specification.md
+++ b/specification/sigma-rules-specification.md
@@ -3,13 +3,12 @@
 - Version 2.0.0
 - Release date 2024-08-08
 
-# Summary
+## Summary
 
 - [Summary](#summary)
-- [Yaml File](#yaml-file)
-  - [Filename](#filename)
-  - [Data](#data)
-- [Structure](#structure)
+- [File Structure](#file-structure)
+  - [Yaml File](#yaml-file)
+  - [Schema](#schema)
 - [Components](#components)
   - [Title](#title)
   - [Identification](#identification)
@@ -22,7 +21,7 @@
   - [References](#references)
   - [Date](#date)
   - [Modified](#modified)
-  - [Log Source](#log-source)
+  - [LogSource](#logsource)
   - [Detection](#detection)
     - [Search-Identifier](#search-identifier)
     - [General](#general)
@@ -38,7 +37,7 @@
     - [Placeholders](#placeholders)
       - [Standard Placeholders](#standard-placeholders)
     - [Keywords search](#keywords-search)
-    - [Condition](#condition)
+  - [Condition](#condition)
   - [Fields](#fields)
   - [FalsePositives](#falsepositives)
   - [Level](#level)
@@ -48,56 +47,7 @@
 - [Sigma Filters](#sigma-filters)
 - [History](#history)
 
-# Yaml File
-
-## Filename
-
-To keep the file names interoperable use the following:
-
-- Length between 10 and 70 characters
-- All characters of the filename should be in lowercase
-- No special characters only letters (a-z) and digits (0-9)
-- Use `_` instead of a space
-- Use `.yml` as a file extension
-
-example:
-
-- lnx_auditd_change_file_time_attr.yml
-- web_cve_2022_33891_spark_shell_command_injection.yml
-- sysmon_file_block_exe.yml
-
-## Data
-
-The rule files are written in [yaml format](https://yaml.org/spec/1.2.2/)
-To keep the rules interoperable use:
-
-- UTF-8
-- LF for the line break (the Windows native editor uses CR-LF)
-- Indentation of 4 spaces
-- Lowercase keys (e.g. title, id, etc.)
-- Strings values use Single quotes `'` . If the string contains a single quote, double quotes may be used instead
-- Numeric values don't use any quotes
-
-Below is a simple Sigma rule example:
-
-```yaml
-title: Whoami Execution
-description: Detects a whoami.exe execution
-references:
-      - https://speakerdeck.com/heirhabarov/hunting-for-privilege-escalation-in-windows-environment
-author: Florian Roth
-date: 2019-10-23
-logsource:
-    category: process_creation
-    product: windows
-detection:
-    selection:
-        Image: 'C:\Windows\System32\whoami.exe'
-    condition: selection
-level: high
-```
-
-# Structure
+## File Structure
 
 The rules consist of a few required sections and several optional ones.
 
@@ -138,11 +88,58 @@ scope [optional]
 [arbitrary custom fields]
 ```
 
+### Yaml File
+
+The rule files are written in [yaml format](https://yaml.org/spec/1.2.2/)
+In order to keep the rules interoperable use the following:
+
+- UTF-8 encoding.
+- LF for the line break (the Windows native editor uses CR-LF).
+- Indentation of 4 spaces.
+- Lowercase keys (e.g. title, id, etc.).
+- Strings values use Single quotes `'` . If the string contains a single quote, double quotes may be used instead.
+- Numeric values don't use any quotes.
+
+Below is a simple Sigma rule example:
+
+```yaml
+title: Whoami Execution
+description: Detects a whoami.exe execution
+references:
+      - https://speakerdeck.com/heirhabarov/hunting-for-privilege-escalation-in-windows-environment
+author: Florian Roth
+date: 2019-10-23
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image: 'C:\Windows\System32\whoami.exe'
+    condition: selection
+level: high
+```
+
+To keep the file names interoperable use the following:
+
+- Length between 10 and 70 characters
+- All characters of the filename should be in lowercase
+- No special characters only letters (a-z) and digits (0-9)
+- Use `_` instead of a space
+- Use `.yml` as a file extension
+
+example:
+
+- ``lnx_auditd_change_file_time_attr.yml``
+- ``web_cve_2022_33891_spark_shell_command_injection.yml``
+- ``sysmon_file_block_exe.yml``
+
+### Schema
+
 The Json schema is defined in [sigma-detection-rule-schema.json](/json-schema/sigma-detection-rule-schema.json)
 
-# Components
+## Components
 
-## Title
+### Title
 
 **Attribute:** title
 
@@ -150,7 +147,7 @@ The Json schema is defined in [sigma-detection-rule-schema.json](/json-schema/si
 
 A brief title for the rule that should contain what the rule is supposed to detect (max. 256 characters)
 
-## Identification
+### Identification
 
 **Attributes:** id, related
 
@@ -168,8 +165,7 @@ id: 929a690e-bef0-4204-a928-ef5e620d6fcc
 It is better to write a rule with a new id for the following reasons:
 
 * Major changes in the rule. E.g. a different rule logic.
-* Derivation of a new rule from an existing or refinement of a rule in a way that both are kept
-  active.
+* Derivation of a new rule from an existing or refinement of a rule in a way that both are kept active.
 * Merging of rules.
 
 To be able to keep track of the relationships between detections, Sigma rules may also contain
@@ -194,7 +190,7 @@ Currently the following types are defined:
   expected that a rule with this id exists anymore.
 * `similar`: Use to relate similar rules to each other (e.g. same detection content applied to different log sources, rule that is a modified version of another rule with a different level)
 
-## Name
+### Name
 
 **Attribute:** name
 
@@ -203,7 +199,7 @@ Currently the following types are defined:
 `name` is a **unique** human-readable name that can be used instead of the *id* as a reference in correlation rules. \
 The goal is to improve the readability of correlation rules.
 
-## Taxonomy
+### Taxonomy
 
 **Attribute:** taxonomy
 
@@ -215,13 +211,11 @@ Defines the taxonomy used in the Sigma rule. A taxonomy can define:
 * field values, example: a field `image_file_name` that only contains a file name like `example.exe` and is transformed into `ImageFile: *\\example.exe`.
 * logsource names, example: `category: ProcessCreation` instead of `category: process_creation`
 
-
-The Default taxonomy is `sigma`. \
-A custom taxonomy must be handled by the used tool or transformed into the default taxonomy.
+The Default taxonomy is `sigma`. A custom taxonomy must be handled by the used tool or transformed into the default taxonomy.
 
 More information on the default taxonomy can be found in the [Sigma Taxonomy Appendix](/appendix/sigma-taxonomy-appendix.md) file.
 
-## Status
+### Status
 
 **Attribute:** status
 
@@ -236,7 +230,7 @@ Declares the status of the rule:
 - `deprecated`: the rule is replaced or covered by another one. The link is established by the `related` field.
 - `unsupported`: the rule cannot be use in its current state (old correlation format, custom fields)
 
-## Description
+### Description
 
 **Attribute:** description
 
@@ -244,7 +238,7 @@ Declares the status of the rule:
 
 A short and accurate description of the rule and the malicious or suspicious activity that can be detected (max. 65,535 characters)
 
-## License
+### License
 
 **Attribute:** license
 
@@ -252,7 +246,7 @@ A short and accurate description of the rule and the malicious or suspicious act
 
 License of the rule according the [SPDX ID specification](https://spdx.org/ids).
 
-## Author
+### Author
 
 **Attribute**: author
 
@@ -261,7 +255,7 @@ License of the rule according the [SPDX ID specification](https://spdx.org/ids).
 Creator of the rule. (can be a name, nickname, twitter handle...etc) \
 If there is more than one, they are separated by a comma.
 
-## References
+### References
 
 **Attribute**: reference
 
@@ -270,7 +264,7 @@ If there is more than one, they are separated by a comma.
 References to the sources that the rule was derived from. \
 These could be blog articles, technical papers, presentations or even tweets.
 
-## Date
+### Date
 
 **Attribute**: date
 
@@ -279,7 +273,7 @@ These could be blog articles, technical papers, presentations or even tweets.
 Creation date of the rule. \
 Use the ISO 8601 date with separator format : YYYY-MM-DD
 
-## Modified
+### Modified
 
 **Attribute**: modified
 
@@ -294,9 +288,9 @@ Reasons to change the modified date:
 * changed detection section
 * changed level
 * changed logsource (rare)
-* changed status to `deprecated` 
+* changed status to `deprecated`
 
-## Log Source
+### LogSource
 
 **Attribute**: logsource
 
@@ -314,7 +308,7 @@ We recommend using a "definition" value in cases in which further explanation is
 
 The `category` value is used to select all log files written of a logical group. \
 This may cover one or more sources of information depending on the system. \
-e.g. "antivirus" for the scan result, "webserver" for the web access logs. 
+e.g. "antivirus" for the scan result, "webserver" for the web access logs.
 
 The `product` value is used to select all log outputs of a certain product. \
 It can be as generic as an operating system or the name of a particular software package. \
@@ -349,7 +343,7 @@ product: windows
 
 More details can be found in the [Sigma Taxonomy Appendix](/appendix/sigma-taxonomy-appendix.md) file, and [SigmaHQ Logsource Guides](https://github.com/SigmaHQ/sigma/tree/master/documentation/logsource-guides)
 
-## Detection
+### Detection
 
 **Attribute**: detection
 
@@ -357,18 +351,18 @@ More details can be found in the [Sigma Taxonomy Appendix](/appendix/sigma-taxon
 
 A set of search-identifiers that represent properties of searches on log data.
 
-### Search-Identifier
+#### Search-Identifier
 
 A definition that can consist of two different data structures - lists and maps.
 
-### General
+#### General
 
 * All values are treated as case-insensitive strings.
 * You can use wildcard characters `*` and `?` in strings (see also [escaping](#escaping) section below).
 * Regular expressions are case-sensitive by default.
 * You don't have to escape characters except the string quotation marks `'`.
 
-### String Wildcard
+#### String Wildcard
 
 Wildcards are used when part of the text is random.
 You can use :
@@ -387,7 +381,7 @@ Sigma has special modifiers to facilitate the search of unbounded strings
 * `something*` see [startswith modifier](#value-modifiers).
 * `*something*` see [contains modifier](#value-modifiers).
 
-### Escaping
+#### Escaping
 
 The backslash character `\` is used for escaping of wildcards `*` and `?` as well as the backslash character itself. Escaping of the backslash is necessary if it is followed by a wildcard depending on the desired result.
 
@@ -399,7 +393,7 @@ Summarized, these are the following possibilities:
 * Three backslashes are necessary to escape both, the backslash and the wildcard and handle them as plain values: `\\\*`.
 * Three or four backslashes are handled as double backslash. Four is recommended for consistency reasons: `\\\\` results in the plain value `\\`.
 
-### Lists
+#### Lists
 
 Lists can contain:
 
@@ -426,7 +420,7 @@ detection:
 
 The example above matches an image value ending with `example.exe` **or** an executable with a description containing the string `Test executable`.
 
-### Maps
+#### Maps
 
 Maps (or dictionaries) consist of key/value pairs, in which the key is a field in the log data and the value is a string or integer value. All elements of a map are joined with a logical 'AND'.
 
@@ -456,7 +450,7 @@ detection:
     condition: selection
 ```
 
-### Field Usage
+#### Field Usage
 
 1. For fields with existing field-mappings, use the mapped field name.
 
@@ -492,7 +486,7 @@ Examples ii:
 * `<Data Name="User">NT AUTHORITY\SYSTEM</Data>` will be `User`
 * `<Data Name="ServiceName">MpKsl4eaa0a76</Data>` will be `ServiceName`
 
-### Special Field Values
+#### Special Field Values
 
 There are special field values that can be used.
 
@@ -514,7 +508,7 @@ detection:
     condition: selection and not filter
 ```
 
-### Field Existence
+#### Field Existence
 
 In some case a field can be optional in the event. You can use the `exists` modifiers to check it.
 
@@ -528,14 +522,13 @@ detection:
     condition: selection
 ```
 
-
-### Value Modifiers
+#### Value Modifiers
 
 The values contained in Sigma rules can be modified by *value modifiers*. Value modifiers are
 appended after the field name with a pipe character `|` as separator and can also be chained, e.g.
 `fieldname|mod1|mod2: value`. The value modifiers are applied in the given order to the value.
 
-#### Modifier Types
+##### Modifier Types
 
 There are two types of value modifiers:
 
@@ -553,7 +546,7 @@ multiple values.
 
 [List of modifiers](appendix/appendix_modifier.md)
 
-### Placeholders
+#### Placeholders
 
 Placeholders are used as values that get their final meaning at conversion or usage time of the rule. This can be, but is not restricted to:
 
@@ -572,7 +565,7 @@ A plain percent character can be used by escaping it with a backslash. Examples:
 
 Placeholders must be handled appropriately by a tool that uses Sigma rules. If the tool isn't able to handle placeholders, it must reject the rule.
 
-#### Standard Placeholders
+##### Standard Placeholders
 
 The following standard placeholders should be used:
 
@@ -584,7 +577,7 @@ The following standard placeholders should be used:
 
 Custom placeholders can be defined as required.
 
-### Keywords search
+#### Keywords search
 
 Contrary to the Field Usage, It's a matter of searching for keywords across an entire event. \
 They are built by using a list under a search-identifiers.
@@ -609,7 +602,7 @@ detection:
 ```
 Give : "OabVirtualDirectory" **and** " -ExternalUrl "
 
-Some rules use simply `keywords` as search-identifiers name to facilitate identification. 
+Some rules use simply `keywords` as search-identifiers name to facilitate identification.
 
 ### Condition
 
@@ -661,7 +654,7 @@ Operator Precedence (least to most binding)
 The condition can be a list, in this case, each of them generates a query
 They are logically linked with OR.
 
-## Fields
+### Fields
 
 **Attribute**: fields
 
@@ -669,7 +662,7 @@ They are logically linked with OR.
 
 A list of log fields that could be interesting in further analysis of the event and should be displayed to the analyst.
 
-## FalsePositives
+### FalsePositives
 
 **Attribute**: falsepositives
 
@@ -677,7 +670,7 @@ A list of log fields that could be interesting in further analysis of the event 
 
 A list of known false positives that may occur.
 
-## Level
+### Level
 
 **Attribute**: level
 
@@ -691,7 +684,7 @@ The level field contains one of five string values. It describes the criticality
 - `high`: Relevant event that should trigger an internal alert and requires a prompt review.
 - `critical`: Highly relevant event that indicates an incident. Critical events should be reviewed immediately. It is used only for cases in which probability borders certainty.
 
-## Tags
+### Tags
 
 **Attribute**: tags
 
@@ -707,7 +700,7 @@ A Sigma rule can be categorized with tags. Tags should generally follow this syn
 
 [More information about tags](/appendix/sigma-tags-appendix.md)
 
-## Scope
+### Scope
 
 **Attribute**: scope
 
@@ -718,21 +711,20 @@ A list of the intended scopes of the rule. This would allow you to define if a r
 For example , if you have a rule for a registry key being set, where the key only exists on windows server installations./
 A scope with the value `server` can be added to limit this rule only to Windows Servers.
 
-# Rule Correlation
+## Rule Correlation
 
-Correlation allows several events to be linked together. /
-To make it easier to read these corelation rules, they are written in meta-rules.
+Correlation allows several events to be linked together. To make it easier to read these corelation rules, they are written in meta-rules.
 
 Check out the [Sigma Correlation Rules Specification](/specification/sigma-correlation-rules-specification.md) for more details.
 
-# Sigma Filters
+## Sigma Filters
 
 To adapt the rules to the environment, it is sometimes useful to put the same exclusion in several rules. /
 Their maintenance can become difficult, with a meta-filter it is possible to write it in a single place.
 
 Check out the [Sigma Filters Specification](/specification/sigma-filters-specification.md) for more details.
 
-# History
+## History
 
 * 2024-08-08 Specification v2.0.0
 * 2023-06-29 Specification v1.0.4

--- a/specification/sigma-rules-specification.md
+++ b/specification/sigma-rules-specification.md
@@ -135,7 +135,7 @@ example:
 
 ### Schema
 
-The Json schema is defined in [sigma-detection-rule-schema.json](/json-schema/sigma-detection-rule-schema.json)
+The Json schema is defined in [sigma-detection-rule-schema.json](/json-schema/sigma-detection-rule-schema.json). Check it out for additional details on the required fields, their types and other information.
 
 ## Components
 


### PR DESCRIPTION
This PR updates the correlation json schema to require certain fields depending on the correlation type as well as formatting of the specs to align with markdown rules.