### PR TITLE
Fixed re sub modifier insensitive description typo

### DIFF
--- a/appendix/sigma-modifiers-appendix.md
+++ b/appendix/sigma-modifiers-appendix.md
@@ -38,7 +38,7 @@ The following document defines the standardized modifiers that can be used in Si
 
 * `re`: Value is handled as a regular expression by backends. Regex is matched case-sensitive by default
 * `re` sub-modifiers:
-  * `i`: (insensitive) to enable case-sensitive matching.
+  * `i`: (insensitive) to enable case-insensitive matching.
   * `m`: (multi line) to match across multiple lines. `^` /`$` match the start/end of line.
   * `s`: (single line) to enable that dot (`.`) matches all characters, including the newline character.
 


### PR DESCRIPTION
Hello :)

I am working on an implementation of Sigma V2 `re|i` sub modifier https://github.com/Yamato-Security/hayabusa/issues/1396 and probably had a typo, so I fixed it.
