### PR TITLE
Fix missing field and typo for Meta Rule

### DIFF
--- a/json-schema/sigma-correlation-rules-schema.json
+++ b/json-schema/sigma-correlation-rules-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Sigma Meta rule specification V2.0.0 (2024-08-08)",
+  "title": "Sigma Meta rule specification V2.0.1 (2024-09-03)",
   "type": "object",
   "required": [
     "title",
@@ -16,6 +16,31 @@
       "type": "string",
       "description": "A globally unique identifier for the Sigma rule. This is recommended to be a UUID v4, but not mandatory.",
       "format": "uuid"
+    },
+    "status": {
+      "type": "string",
+      "oneOf": [
+        {
+          "const": "stable",
+          "description": "The rule didn't produce any obvious false positives in multiple environments over a long period of time"
+        },
+        {
+          "const": "test",
+          "description": "The rule doesn't show any obvious false positives on a limited set of test systems"
+        },
+        {
+          "const": "experimental",
+          "description": "A new rule that hasn't been tested outside of lab environments and could lead to many false positives"
+        },
+        {
+          "const": "deprecated",
+          "description": "The rule was replaced or is now covered by another one. The link between both rules is made via the `related` field"
+        },
+        {
+          "const": "unsupported",
+          "description": "The rule can not be used in its current state (special correlation log, home-made fields, etc.)"
+        }
+      ]
     },
     "description": {
       "type": "string",
@@ -94,7 +119,7 @@
             }
           ]
         },
-        "alias": {
+        "aliases": {
           "type": "object",
           "description": "Defines field name aliases that are applied to correlated Sigma rules",
           "additionalProperties": {
@@ -184,6 +209,23 @@
         {
         "if": { "properties": {"type": {"const": "value_count"}}},
         "then": {"required": ["condition", "field", "group-by", "timespan"]}
+        }
+      ]
+    },
+    "falsepositives": {
+      "description": "A list of known false positives that may occur",
+      "uniqueItems": true,
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 2
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 2
+          }
         }
       ]
     },

--- a/specification/sigma-correlation-rules-specification.md
+++ b/specification/sigma-correlation-rules-specification.md
@@ -2,8 +2,8 @@
 
 The following document defines the standardized correlation that can be used in Sigma rules.
 
-* Version 2.0.0
-* Release date 2024-08-08
+* Version 2.0.1
+* Release date 2024-09-03
 
 - [Introduction](#introduction)
   - [Compatibility](#compatibility)
@@ -17,6 +17,7 @@ The following document defines the standardized correlation that can be used in 
   - [Components](#components)
     - [Title](#title)
     - [Identification](#identification)
+    - [Status](#status)
     - [Description](#description)
     - [Author](#author)
     - [References](#references)
@@ -29,6 +30,7 @@ The following document defines the standardized correlation that can be used in 
       - [Grouping](#grouping)
       - [Time Selection](#time-selection)
       - [Condition](#condition)
+    - [FalsePositives](#falsepositives)
     - [Level](#level)
     - [Generate](#generate)
   - [Correlation Types](#correlation-types)
@@ -140,6 +142,21 @@ An example for this is:
 title: login brute force
 id: 0e95725d-7320-415d-80f7-004da920fc11
 ```
+
+#### Status
+
+**Attribute:** status
+
+**Use:** optional
+
+Declares the status of the rule:
+
+- `stable`: the rule is considered as stable and may be used in production systems or dashboards.
+- `test`: a mostly stable rule that could require some slight adjustments depending on the environement.
+- `experimental`: an experimental rule that could lead to false positives results or be noisy, but could also identify interesting
+  events.
+- `deprecated`: the rule is replaced or covered by another one. The link is established by the `related` field.
+- `unsupported`: the rule cannot be use in its current state (old correlation format, custom fields)
 
 #### Description
 
@@ -298,6 +315,14 @@ condition:
 
 If you need more complex constructs, you can always chain correlation rules together.
 See the examples at the far bottom, for more details.
+
+#### FalsePositives
+
+**Attribute**: falsepositives
+
+**Use:** optional
+
+A list of known false positives that may occur.
 
 #### Level
 
@@ -563,5 +588,6 @@ detection:
 ```
 
 ## History
-
+* 2024-09-03 Specification V2.0.1
+  * add missing `status` and `falsepositives`
 * 2024-08-08 Specification v2.0.0


### PR DESCRIPTION
- Add missing field `status` and `falsepositives`
- Fix `aliases` in the json