### PR TITLE
Update dead link in sigma-rules-specification.md

### DIFF
--- a/specification/sigma-rules-specification.md
+++ b/specification/sigma-rules-specification.md
@@ -544,7 +544,7 @@ There are two types of value modifiers:
 Generally, value modifiers work on single values and value lists. A value might also expand into
 multiple values.
 
-[List of modifiers](appendix/appendix_modifier.md)
+[List of modifiers](appendix/sigma-modifiers-appendix.md)
 
 #### Placeholders
 


### PR DESCRIPTION
"List of modifiers" in the rule specification was linked to an old document.