### PR TITLE
Fix correlation temporal rule example's indent

### DIFF
--- a/specification/sigma-correlation-rules-specification.md
+++ b/specification/sigma-correlation-rules-specification.md
@@ -421,7 +421,7 @@ Simple example : Reconnaissance commands defined in three Sigma rules are invoke
 
 ```yaml
 correlation:
-type: temporal
+    type: temporal
     rules:
         - recon_cmd_a
         - recon_cmd_b


### PR DESCRIPTION
Thank you for maintaining docs :)
I found a wrong indent in the `correlation:temporal` rule and fixed it.