### PR TITLE
fix: discrepancy between text and JSON scheme

### DIFF
--- a/json-schema/sigma-detection-rule-schema.json
+++ b/json-schema/sigma-detection-rule-schema.json
@@ -194,19 +194,11 @@
     "falsepositives": {
       "description": "A list of known false positives that may occur",
       "uniqueItems": true,
-      "anyOf": [
-        {
-          "type": "string",
-          "minLength": 2
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 2
-          }
-        }
-      ]
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 2
+      }
     },
     "level": {
       "type": "string",


### PR DESCRIPTION
the README states that the `falsepositives` field is a list of possible false positives, but the JSON schema allows for single `string` values

https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md#falsepositives