### PR TITLE
Allow multiple fields in value_count

### DIFF
--- a/json-schema/sigma-correlation-rules-schema.json
+++ b/json-schema/sigma-correlation-rules-schema.json
@@ -185,9 +185,20 @@
             },
             {
               "field": {
-                "description": "Name of the field to count values",
-                "type": "string",
-                "maxLength": 256
+                "description": "Name of the field(s) to count values",
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "maxLength": 256
+                  },
+                  {
+                    "type": "array",
+                    "items": {           
+                      "type": "string",
+                      "maxLength": 256
+                    }
+                  }
+                ]                
               }
             }
           ]

--- a/specification/sigma-correlation-rules-specification.md
+++ b/specification/sigma-correlation-rules-specification.md
@@ -386,6 +386,8 @@ Counts values in a field defined by `field`.
 The resulting query must count field values separately for each group specified by group-by.
 The condition finally defines how many values must occur to generate a search hit.
 
+When you use multiple values in `field` they are linked by an **AND**.
+
 Requires:
   - `group-by`
   - `timespan`


### PR DESCRIPTION
In `value_count` rules, it can be useful to count the number of different field value tuples (such as `(TargetDomainName, TargetUserName)` to represent a user).

`pySigma` already accepts a list of strings for `condition.field`.

After discussion with @frack113 , this PR adds a sentence to state the expected behavior when providing multiple fields in `condition.field`. It also updates the correlation rules schema.