### PR TITLE
Add Issue Template for SEP

### DIFF
--- a/.github/ISSUE_TEMPLATE/sigma-enhancement-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/sigma-enhancement-proposal.yml
@@ -113,7 +113,7 @@ body:
         - label: "YAML structure changes"
         - label: "Sigma conversion tools (pySigma)"
         - label: "Backend updates"
-        - label: "Documentation only"
+        - label: "Documentation"
 
   - type: checkboxes
     id: submitter_checklist


### PR DESCRIPTION
This PR aims to add a new issue template for a new concept we are introducing called. Sigma Enhancement Proposals.

Any enhancement ideas or new feature proposal to the sigma specs must be submitted through the SEP program. Where a SEP number will be assigned and the proposal will be reviewed.

The template has a bunch of required fields that aims to clarify exactly what the propsal is aiming to resolve / introduce.