### PR TITLE
[v2.2.0] Updates `filters` with the `any` rule spec

### DIFF
--- a/changelog/version-2.1-2.2.md
+++ b/changelog/version-2.1-2.2.md
@@ -30,7 +30,7 @@ The following is a non-exhaustive list of changes between the v2.1.0 and v2.2.0 
 
 ## Filter
 
-- Filters can now reference all available rules by using the `filter.rules: all` declaration [PR #430](https://github.com/SigmaHQ/pySigma/pull/430)
+- Filters can now reference all available rules by using the `filter.rules: any` declaration [PR #430](https://github.com/SigmaHQ/pySigma/pull/430)
 
 ## Rules
 

--- a/changelog/version-2.1-2.2.md
+++ b/changelog/version-2.1-2.2.md
@@ -30,6 +30,8 @@ The following is a non-exhaustive list of changes between the v2.1.0 and v2.2.0 
 
 ## Filter
 
+- Filters can now reference all available rules by using the `filter.rules: all` declaration [PR #430](https://github.com/SigmaHQ/pySigma/pull/430)
+
 ## Rules
 
 - `Lists` and `Maps` : add scalar value

--- a/specification/sigma-filters-specification.md
+++ b/specification/sigma-filters-specification.md
@@ -2,8 +2,8 @@
 
 The following document defines the standardized global filter that can be used with Sigma rules.
 
-- Version 2.1.0
-- Release date 2025-08-02
+- Version 2.2.0
+- Release date 2025-08-03
 
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
@@ -150,7 +150,13 @@ Read more on the `logsource` attribute in the [Sigma Rules Specification](sigma-
 
 **Use:** mandatory
 
-refers to one or multiple Sigma rules where to add the filter
+Refers to one or multiple Sigma rules where to add the filter.
+A rule can be referred to by the `id` of a Sigma rule.
+
+The `rules` attribute can be:
+
+- A list of one or multiple Sigma rule IDs
+- The string `any` or `all` - applies the filter to all Sigma rules matching the specified `logsource`
 
 ##### filter selection
 
@@ -187,7 +193,24 @@ filter:
     condition: selection
 ```
 
+Example with `any` to apply filter to all process creation rules:
+
+```yaml
+title: Filter Administrator account for all process creation rules
+description: The valid administrator account start with adm_
+logsource:
+    category: process_creation
+    product: windows
+filter:
+    rules: any
+    selection:
+        User|startswith: 'adm_'
+    condition: selection
+```
+
 ## History
 
+- 2025-08-03 Specification v2.2.0
+  - Added support for `any` and `all` string values in the `rules` attribute to match all rules with the specified logsource
 - 2025-08-02 Specification v2.1.0
 - 2024-08-08 Specification v2.0.0

--- a/specification/sigma-filters-specification.md
+++ b/specification/sigma-filters-specification.md
@@ -3,7 +3,7 @@
 The following document defines the standardized global filter that can be used with Sigma rules.
 
 - Version 2.2.0
-- Release date 2025-08-03
+- Release date 2025-XX-XX
 
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 

--- a/specification/sigma-filters-specification.md
+++ b/specification/sigma-filters-specification.md
@@ -156,7 +156,7 @@ A rule can be referred to by the `id` of a Sigma rule.
 The `rules` attribute can be:
 
 - A list of one or multiple Sigma rule IDs
-- The string `any` or `all` - applies the filter to all Sigma rules matching the specified `logsource`
+- The string `any` applies the filter to all Sigma rules matching the specified `logsource`
 
 ##### filter selection
 
@@ -208,15 +208,15 @@ filter:
     condition: selection
 ```
 
-Example with a filter that contains a superset of a logsource, such that it applies to all rules with a more specific logsource. The example below would apply to all Windows rules, regardless of category, or product version.
+Example with a filter that contains a superset of a logsource, such that it applies to all rules with a more specific logsource. The example below would apply to all Windows rules, regardless of "category", or "service".
 
 ```yaml
-title: Filter out all Windows rules for non system / administrator accounts
-description: Excludes Windows SYSTEM and LOCAL SERVICE accounts from all Windows rules
+title: Filter out any Windows rules for non system / administrator accounts
+description: Excludes Windows SYSTEM and LOCAL SERVICE accounts from any Windows rules
 logsource:
     product: windows
 filter:
-    rules: all
+    rules: any
     selection:
         User:
             - 'SYSTEM'
@@ -227,6 +227,6 @@ filter:
 ## History
 
 - 2025-08-03 Specification v2.2.0
-  - Added support for `any` and `all` string values in the `rules` attribute to match all rules with the specified logsource
+  - Added support for `any` string values in the `rules` attribute to match all rules with the specified logsource
 - 2025-08-02 Specification v2.1.0
 - 2024-08-08 Specification v2.0.0

--- a/specification/sigma-filters-specification.md
+++ b/specification/sigma-filters-specification.md
@@ -196,8 +196,8 @@ filter:
 Example with `any` to apply filter to all process creation rules:
 
 ```yaml
-title: Filter Administrator account for all process creation rules
-description: The valid administrator account start with adm_
+title: Filter for Administrator account across all process creation rules
+description: The valid administrator account start with adm_ when creating processes
 logsource:
     category: process_creation
     product: windows
@@ -206,6 +206,22 @@ filter:
     selection:
         User|startswith: 'adm_'
     condition: selection
+```
+
+Example with a filter that contains a superset of a logsource, such that it applies to all rules with a more specific logsource. The example below would apply to all Windows rules, regardless of category, or product version.
+
+```yaml
+title: Filter out all Windows rules for non system / administrator accounts
+description: Excludes Windows SYSTEM and LOCAL SERVICE accounts from all Windows rules
+logsource:
+    product: windows
+filter:
+    rules: all
+    selection:
+        User:
+            - 'SYSTEM'
+            - 'LOCAL SERVICE'
+    condition: not selection
 ```
 
 ## History


### PR DESCRIPTION
This pull request updates the Sigma Filters Specification to version 2.2.0, introducing new functionality for the `rules` attribute in filters. The main enhancement is the ability to use the string value `any` to apply filters more broadly to Sigma rules matching a specified `logsource`. The documentation is updated accordingly, with new examples and a revision to the version history.

Key changes:

**Specification enhancements:**
* The `rules` attribute in a filter can now be set to the string `any`, allowing the filter to apply to all Sigma rules matching the specified `logsource`.
* Added documentation and YAML examples demonstrating how to use `any` with the `rules` attribute for broader filter application.

**Documentation updates:**
* Bumped the specification version to 2.2.0 and updated the release date.
* Updated the version history to reflect the new feature in v2.2.0.