### PR TITLE
Fix typo in sigmahq-rule-convention.md

### DIFF
--- a/sigmahq/sigmahq-rule-convention.md
+++ b/sigmahq/sigmahq-rule-convention.md
@@ -136,7 +136,7 @@ falsepositives:
     - Administrators or administrator scripts might sometimes generate similar activity
 ```
 
-- In cases where the author doesn't know of any false positives then value the should be `Unknown`.
+- In cases where the author doesn't know of any false positives the value should be `Unknown`.
 - If the rule author doesn't expect false positives the value should be `Unlikely`.
 
 Also please note the following


### PR DESCRIPTION
This PR fixes a small typo in the false positive description.
No functional changes.