### PR TITLE
Fix grammar and clarity in sigmahq-title-convention.md

### DIFF
--- a/sigmahq/sigmahq-title-convention.md
+++ b/sigmahq/sigmahq-title-convention.md
@@ -22,7 +22,7 @@ Note that this is by no means an exhaustive list. It is meant to be a general gu
 
 Bearing in mind that the title is one of the first things that an analyst will see. It should therefore be used as a clue and be as clear as possible to guide the assessment of the alert.
 
-The title and level of the rule must be consistent
+The title and level of the rule must be consistent.
 
 ## Structure
 
@@ -47,7 +47,7 @@ Specific wording example:
 
 ### Suffix (Optional)
 
-Sometimes the detections are duplicated across different `logsource`s with little changes to their logic. This is common in the case of Process Creation rules targeting the PowerShell process. Those rules are typically duplicated for the different PowerShell `logsource`s using ScriptBlockText to check for the same characteristics. A suffix in this case will be used to differentiate between the rules of the different `logsource`s.
+Sometimes the detections are duplicated across different `logsource`s with little changes to their logic. This is common in Process Creation rules targeting the PowerShell process. These rules are typically duplicated for different PowerShell `logsource`s using ScriptBlockText to check for the same characteristics. In this case a suffix is used to differentiate between rules of different `logsource`s.
 
 Example:
 
@@ -76,7 +76,7 @@ Example:
 
 #### Informational / Low Level Rules
 
-Events matching rules of level `informational` or `low` are not intended to be used to create alerts on their own. Their purpose is to conserve events or criteria of relevance, to be used in correlations or for ideas for threat hunting. A rule of those levels will by definition not create false positives as they should not be used for alerting.
+Events matching rules of level `informational` or `low` are not intended to be used to create alerts on their own. Their purpose is to capture relevant events or criteria for use in correlations or as input for threat hunting. A rule of those levels will by definition not create false positives as they should not be used for alerting.
 
 The title should therefore be general and should not indicate that the rule describes suspicious or malicious behavior.
 
@@ -84,23 +84,23 @@ Example : `Net.exe Execution`
 
 #### Medium Level Rules
 
-Events matching `medium` level rules rules can have environment dependent false positives and require a tuning/evaluation phase before deploying to production environments.
+Events matching `medium` level rules can have environment dependent false positives and require a tuning/evaluation phase before deploying to production environments.
 
 Keywords used to indicate this:
 
-- "Potential "
+- "Potential"
 
 #### High Level Rules
 
-Events matching `high` level rules requires a prompt review.
+Events matching `high` level rules require a prompt review.
 
 Keywords used to indicate this:
 
-- "Suspicious "
+- "Suspicious"
 
 #### Critical Level Rules
 
-Events matching `critical` level rules should be reviewed immediately
+Events matching `critical` level rules should be reviewed immediately.
 The title must therefore be precise and indicate the specific threat.
 
 Keywords used to indicate this:


### PR DESCRIPTION
This PR fixes minor grammar issues and improves clarity in sigmahq-title-convention.md.
No functional changes.